### PR TITLE
Ship ScaleForce scaffolding to main

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,23 @@
+title: "[Idea] "
+labels: ["idea"]
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: What's the idea?
+      description: A short description of what you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why does this matter?
+      description: What problem does it solve, or what value would it add?
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional notes
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/q-and-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-and-a.yml
@@ -1,0 +1,16 @@
+title: "[Q] "
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Your question
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What were you trying to do? What have you already checked?
+    validations:
+      required: false

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,15 @@
+title: "[Show & Tell] "
+labels: ["show-and-tell"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What did you build / learn / try?
+    validations:
+      required: true
+  - type: textarea
+    id: links
+    attributes:
+      label: Links, screenshots, demos
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report a defect — something is broken or behaves incorrectly.
+labels: ["bug", "intake"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. `scaleforce[bot]` will triage this and may ask follow-up questions.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I do X, Y happens instead of Z.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Node version, relevant package versions, deployment context.
+      placeholder: |
+        - OS:
+        - Node:
+        - Probot:
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / error output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / Question
+    url: https://github.com/thomHayner/scaleforce-github-orchestrator/discussions
+    about: For open-ended questions, ideas, or discussion, please start a Discussion instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,24 @@
+name: Documentation issue
+description: Report missing, incorrect, or unclear documentation.
+labels: ["documentation", "intake"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where is the docs issue?
+      description: File path, URL, or section.
+      placeholder: docs/setup/branching.md
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What's wrong, missing, or unclear?
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Suggest a new feature or enhancement.
+labels: ["enhancement", "intake"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the user pain or need. Avoid jumping to a solution.
+    validations:
+      required: true
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why they're worse.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Mockups, links, related issues.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+PR title: under 70 chars, imperative ("Add X", "Fix Y", "Refactor Z").
+Target: dev (default) | main (release-only) | hotfix → main
+-->
+
+## Summary
+
+<!-- One or two sentences. What changed and why. -->
+
+## Related
+
+- Issue / Discussion: #
+- Spec: `docs/specs/...` (if applicable)
+- ADR: `docs/adr/...` (required if architecture-affecting)
+
+## Test plan
+
+<!-- How to verify this works. Even short bullet checklists are fine. -->
+- [ ] Unit/integration tests pass (`npm test`)
+- [ ] Manual verification: ...
+
+## Checklist
+
+- [ ] One logical change per PR
+- [ ] CLAUDE.md / AGENTS.md rules respected
+- [ ] If architecture-affecting: ADR added or updated
+- [ ] If new dependency: justified in Summary
+- [ ] If touching `llm-wiki/`-relevant knowledge: wiki updated
+
+## Notes for reviewer
+
+<!-- Anything specific the reviewer should focus on. Tradeoffs you considered. Things you're unsure about. -->

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,6 +1,8 @@
-# AIHawk_Birdwatcher
+# ScaleForce
 
-> A GitHub App built with [Probot](https://github.com/probot/probot) and integrated with [OpenAI](https://platform.openai.com).  An intelligent GitHub Repository Maintainer Agent for: triaging Issues, reviewing Pull Requests, and moderating Discussions; can be trained on a repository Wiki as well for FAQ and troubleshooting, backwards compatible for existing repositories with issues, pr and discussions histories.
+> A GitHub-native orchestration bot built with [Probot](https://github.com/probot/probot) and integrated with [OpenAI](https://platform.openai.com). ScaleForce triages issues, mediates PR review threads between human and AI contributors (Claude, Copilot), and coordinates the agentic dev workflow inside the repo.
+
+Posts as `scaleforce[bot]`. Lives alongside `claude[bot]` (substantive AI work) and `copilot-swe-agent[bot]` (parallel coding agent), with the human maintainer as the final reviewer.
 
 ## Setup
 
@@ -16,18 +18,23 @@ npm start
 
 ```sh
 # 1. Build container
-docker build -t AIHawk_Birdwatcher .
+docker build -t scaleforce-bot .
 
 # 2. Start container
-docker run -e APP_ID=<app-id> -e PRIVATE_KEY=<pem-value> AIHawk_Birdwatcher
+docker run -e APP_ID=<app-id> -e PRIVATE_KEY=<pem-value> scaleforce-bot
 ```
+
+## Repo conventions
+
+- See [`CLAUDE.md`](../CLAUDE.md) and [`AGENTS.md`](../AGENTS.md) for agent rules.
+- See [`docs/`](../docs/) for product docs (vision, PRDs, specs, ADRs, roadmap).
+- See [`docs/setup/branching.md`](../docs/setup/branching.md) for the branch model.
+- ADRs use [MADR](https://adr.github.io/madr/) format in [`docs/adr/`](../docs/adr/).
 
 ## Contributing
 
-If you have suggestions for how AIHawk_Birdwatcher could be improved, or want to report a bug, open an issue! We'd love all and any contributions.
-
-For more, check out the [Contributing Guide](CONTRIBUTING.md).
+Open an issue or start a Discussion. PRs welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## License
 
-[ISC](LICENSE) © 2024 thomHayner
+[ISC](../LICENSE) © 2024 thomHayner

--- a/.github/UserNoAiYesTemplates/ISSUE_TEMPLATE/config.yml
+++ b/.github/UserNoAiYesTemplates/ISSUE_TEMPLATE/config.yml
@@ -5,5 +5,5 @@ contact_links:
   #   about: You can join the discussions on Discord.
   - name: New issue
     url: >-
-      https://github.com/thomHayner/LinkedIn_AIHawk_Birdwatcher.github/CONTRIBUTING.md
+      https://github.com/thomHayner/scaleforce-github-orchestrator/blob/main/.github/CONTRIBUTING.md
     about: "Before opening a new issue, please make sure to read CONTRIBUTING.md"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Auth: Max subscribers use a long-lived OAuth token generated
+          # locally with `claude setup-token`. API users use ANTHROPIC_API_KEY.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Optional: pin model
           # model: claude-opus-4-7

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+# Triggered when @claude is mentioned in an issue, PR, or review comment.
+# Runs the Claude Code Action with full repo context. Posts as claude[bot].
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Optional: pin model
+          # model: claude-opus-4-7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+Conventions for **all AI agents** working in this repo (Claude, Copilot, Codex, Cursor, etc.). Agent-specific rules live in `CLAUDE.md`, `.github/copilot-instructions.md`, etc.
+
+## Who's who
+
+| Identity | Role |
+|---|---|
+| `thomHayner` | Human maintainer, final reviewer, merger |
+| `scaleforce[bot]` | Orchestration: triage, routing, PR-thread mediation, label management |
+| `claude[bot]` | Substantive AI work — code, deep PR reviews, spec drafting |
+| `copilot-swe-agent[bot]` | Parallel coding agent, often producing competing PRs |
+| `dependabot[bot]`, `vercel[bot]`, etc. | Standard infra bots |
+
+Agents have distinct identities **on purpose**. Do not impersonate the maintainer or another agent.
+
+## Universal rules
+
+1. **Preserve commit attribution.** Commits are authored by the maintainer's git identity; AI contribution is recorded via `Co-Authored-By:` trailers. Never modify `git config user.*`.
+2. **Don't @-mention the maintainer when posting under their identity.** It self-tags them.
+3. **Architecture-affecting changes require an ADR** in [`docs/adr/`](docs/adr/) (MADR format). If you're not sure whether your change qualifies, err on the side of writing one.
+4. **Branch model**: `feature/* → dev → main`. `main` is release-only. See [`docs/setup/branching.md`](docs/setup/branching.md).
+5. **One logical change per PR.** Refactors separate from features.
+6. **Read `docs/` before starting nontrivial work**: vision → roadmap → specs → adr.
+7. **Update `llm-wiki/`** when you learn something durable that future agents will need (a non-obvious convention, an integration quirk, a decision rationale not yet in an ADR).
+
+## Where to find things
+
+- Product context: [`docs/`](docs/)
+- Synthesized agent-readable knowledge: [`llm-wiki/`](llm-wiki/)
+- Repo automations: [`.github/workflows/`](.github/workflows/)
+- Issue/PR/Discussion templates: [`.github/`](.github/)
+- AI-internal label templates (used by `scaleforce[bot]` to apply labels): [`.github/UserNoAiYesTemplates/`](.github/UserNoAiYesTemplates/)
+
+## Per-agent guides
+
+- Claude → [`CLAUDE.md`](CLAUDE.md)
+- Copilot → `.github/copilot-instructions.md` *(create when needed)*
+- Codex / Cursor → read this file plus [`CLAUDE.md`](CLAUDE.md); the rules are the same.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,58 @@
+# CLAUDE.md
+
+Conventions for Claude Code (and Claude when invoked via the GitHub App) working in this repo.
+
+## Identity & attribution
+
+This repo runs an "AI agency" pattern with multiple distinct identities. **Knowing who you are posting as is load-bearing.**
+
+- **You (Claude)** post on GitHub as `claude[bot]` when invoked via the Claude GitHub App / Claude Code Action. Locally, you may shell to `gh` under whatever account is authenticated — verify with `gh auth status` before posting anything.
+- **The maintainer** is `thomHayner`. They are a human; their comments and reviews are theirs alone.
+- **The orchestration bot** (this repo's Probot) is `scaleforce[bot]`. It handles triage, routing, and PR-thread mediation.
+- **Other agents**: `copilot-swe-agent[bot]`, `dependabot[bot]`, `vercel[bot]`, etc.
+
+### Comment authoring rules
+
+1. **Never @-mention the maintainer when posting under their account.** If `gh auth status` shows you're authenticated as `thomHayner` (or anyone other than a bot), do not write `@thomHayner` in the comment body — it would self-tag them.
+2. **When posting as a bot, normal @-mentions are fine and encouraged** when human attention is needed.
+3. **Never modify `git config user.name` or `git config user.email`.** Commits must be authored by the human maintainer's email so they appear on the maintainer's contribution graph. Use `Co-Authored-By: Claude <noreply@anthropic.com>` trailers to mark AI contribution. This is the convention that keeps "we worked together" visible.
+4. **Do not post substantive replies on behalf of the maintainer.** If a thread needs an AI reply, route through the Claude GitHub App so the comment is attributed to `claude[bot]`. If that's not available, leave a draft in `docs/drafts/` for the maintainer to review and post manually.
+
+## Branch model
+
+- `main` is protected, release-only. Never push directly.
+- `dev` is the working branch. Direct commits are allowed when iterating with the maintainer.
+- `feature/*` branches are optional — used when work is large enough to deserve isolation, or when multiple agents are working in parallel.
+- Flow: `feature/* → PR → dev` (optional), `dev → PR → main` on release.
+- See [`docs/setup/branching.md`](docs/setup/branching.md) for detail.
+
+## ADRs
+
+Architecture-affecting changes require an ADR in [`docs/adr/`](docs/adr/) using [MADR](https://adr.github.io/madr/) format. If your PR meaningfully changes structure, dependencies, deployment, identity boundaries, or external integrations, write or update the relevant ADR in the same PR.
+
+## Where to find context
+
+Read in this order before starting nontrivial work:
+
+1. [`docs/vision/`](docs/vision/) — what we're building and why.
+2. [`docs/roadmap/`](docs/roadmap/) — what's next.
+3. [`docs/specs/`](docs/specs/) — current in-flight specs.
+4. [`docs/adr/`](docs/adr/) — accepted decisions; do not contradict them without a new ADR.
+5. [`llm-wiki/`](llm-wiki/) — synthesized, agent-friendly knowledge derived from the above plus PR-thread history.
+6. [`AGENTS.md`](AGENTS.md) — conventions shared by all agents (you, Copilot, Codex).
+
+## PR conventions
+
+- Title under 70 chars, imperative ("Add X", "Fix Y").
+- Body uses [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+- Link the relevant spec or ADR.
+- For features: include a brief test plan even if tests are added.
+- One logical change per PR. Refactors and feature work go in separate PRs unless impossible.
+
+## Things to avoid
+
+- Don't introduce new dependencies without a one-line justification in the PR body.
+- Don't write speculative "future-proofing" abstractions. Three similar lines is better than a premature interface.
+- Don't add comments that restate the code. Comments explain *why*, not *what*.
+- Don't create documentation files unless asked or unless an ADR/spec is genuinely warranted.
+- Don't bypass git hooks (`--no-verify`) without explicit maintainer approval.

--- a/app.yml
+++ b/app.yml
@@ -124,13 +124,13 @@ default_permissions:
   # https://developer.github.com/v3/apps/permissions/
   # organization_administration: read
 # The name of the GitHub App. Defaults to the name specified in package.json
-# name: My Probot App
+name: ScaleForce
 
 # The homepage of your GitHub App.
-# url: https://example.com/
+url: https://scaleforce.agency/
 
 # A description of the GitHub App.
-# description: A description of my awesome app
+description: GitHub-native orchestration bot. Triages issues, mediates PR review threads between human and AI contributors, and coordinates the agentic dev workflow.
 
 # Set to true when your GitHub App is available to the public or false when it is only accessible to the owner of the app.
 # Default: true

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# docs/
+
+The product layer — what we're building, why, and the decisions that shape it. Versioned with the code, reviewable in PRs.
+
+## Layout
+
+| Folder | Contents |
+|---|---|
+| [`vision/`](vision/) | The "why" — vision statements, north-star principles, target users |
+| [`prd/`](prd/) | Product requirements documents, feature briefs |
+| [`specs/`](specs/) | In-flight technical specs (paired with issues/PRs) |
+| [`roadmap/`](roadmap/) | What's next, ordered by priority and quarter |
+| [`architecture/`](architecture/) | High-level system designs, diagrams, integration maps |
+| [`adr/`](adr/) | Architecture Decision Records (MADR format) |
+| [`setup/`](setup/) | Operational docs: branching, bot identities, deploy |
+| `drafts/` | Scratch space for AI-generated drafts awaiting human review (created on demand) |
+
+## Where this layer ends
+
+`docs/` is human-curated source-of-truth. It is **not** the place for ephemeral chatter, generated summaries, or agent scratch notes — those go in PR threads or [`llm-wiki/`](../llm-wiki/).

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,35 @@
+# 0001. Record architecture decisions
+
+- **Status**: accepted
+- **Date**: 2026-04-18
+- **Deciders**: @thomHayner
+- **Tags**: process, governance
+
+## Context and Problem Statement
+
+ScaleForce is a multi-agent codebase where decisions are made in collaboration with AI contributors. PR threads, Slack-equivalents, and chat history are not durable enough to capture the *why* behind structural decisions — six months from now, neither the maintainer nor any agent will remember the rationale.
+
+We need a lightweight, version-controlled way to record decisions so future contributors (human and AI) can see what was decided and why.
+
+## Decision Drivers
+
+- Agents need durable context to avoid re-litigating settled decisions.
+- The maintainer wants to operate at the PM/reviewer level, not re-explain rationale repeatedly.
+- Decisions should be reviewable in PRs, not buried in a wiki.
+
+## Considered Options
+
+- **MADR** (Markdown Any Decision Records): lightweight, popular, well-tooled.
+- **Nygard original**: more formal, longer, less commonly used today.
+- **No formal format**: ad-hoc decision notes scattered across `docs/`.
+
+## Decision Outcome
+
+Chosen: **MADR**, in [`docs/adr/`](.), one file per decision, sequentially numbered.
+
+### Consequences
+
+- Good: agents and humans have a stable place to look up "why is it this way?"
+- Good: decisions are reviewed and discussed in PRs.
+- Bad: small process overhead — every architecture-affecting PR must add or update an ADR.
+- Neutral: existing decisions need to be backfilled as ADRs over time.

--- a/docs/adr/0002-use-feature-dev-main-branch-model.md
+++ b/docs/adr/0002-use-feature-dev-main-branch-model.md
@@ -1,0 +1,42 @@
+# 0002. Use `feature → dev → main` branch model
+
+- **Status**: accepted
+- **Date**: 2026-04-18
+- **Deciders**: @thomHayner
+- **Tags**: process, branching
+
+## Context and Problem Statement
+
+The maintainer works alongside multiple AI agents that may produce parallel PRs. We need a branch model that:
+
+- Lets the maintainer iterate quickly with agents (sometimes committing directly without ceremony).
+- Provides a clear staging area where multiple in-flight changes can integrate before release.
+- Keeps `main` stable and release-only.
+
+## Decision Drivers
+
+- Agents producing parallel PRs need a common integration target that isn't `main`.
+- The maintainer should not be forced through a feature-branch ceremony for every small change.
+- `main` must remain a clean, releasable history.
+
+## Considered Options
+
+- **Trunk-based, PRs to `main` only**: simplest, but no staging buffer for multi-agent integration.
+- **GitFlow** (`feature` → `develop` → `release` → `main` + hotfix): too heavy.
+- **`feature/* → dev → main`**: `dev` is the integration branch; feature branches optional; release-time PR from `dev` to `main`.
+
+## Decision Outcome
+
+Chosen: **`feature/* → dev → main`**.
+
+- `main`: protected, release-only. Required reviews. No direct pushes.
+- `dev`: working integration branch. Direct commits permitted when iterating with the maintainer. Long-running.
+- `feature/*`: optional. Used when work is large enough to deserve isolation, or when multiple agents are working in parallel.
+- Release: PR from `dev` to `main`. Tag and release from `main`.
+
+### Consequences
+
+- Good: matches actual workflow — quick iteration on `dev`, clean `main`.
+- Good: gives parallel agent PRs an integration target without polluting `main`.
+- Bad: requires explicit release discipline ("when do we cut from `dev` to `main`?").
+- Neutral: `dev` history will be messier than `main`. That's the tradeoff.

--- a/docs/adr/0003-bot-identity-separation.md
+++ b/docs/adr/0003-bot-identity-separation.md
@@ -1,0 +1,48 @@
+# 0003. Separate bot identities for orchestration vs. AI work
+
+- **Status**: accepted
+- **Date**: 2026-04-18
+- **Deciders**: @thomHayner
+- **Tags**: identity, bots, governance
+
+## Context and Problem Statement
+
+When multiple AI tools act in a repo (Claude, Copilot, an orchestration bot, Dependabot, etc.), it must be **visually unambiguous** in any thread who said what. Conflating identities — especially having Claude post comments as the human maintainer — destroys the audit trail and makes review painful.
+
+A particular failure mode observed: running Claude Code locally, where `gh` is authenticated as the maintainer, causes Claude to post comments and open issues *as the maintainer*. This was wrong.
+
+## Decision Drivers
+
+- Each actor in a thread must have a distinct visual identity.
+- Commit attribution should still credit the maintainer (with `Co-Authored-By:` for AI contribution).
+- The maintainer wants @-mentions from AI agents to feel like real pings, not self-tags.
+
+## Considered Options
+
+- **Single bot for everything** (e.g., one Probot doing both orchestration and AI responses): conflates roles.
+- **Bot account (User type)**: a separate GitHub user account for AI activity. Works, but adds a user to manage and can't be owned by an org.
+- **Multiple GitHub Apps with distinct bot identities**: each gets `[bot]` pill automatically, owned by org, no extra user.
+
+## Decision Outcome
+
+Chosen: **Multiple GitHub Apps**, each with its own role and identity:
+
+| Identity | App | Role |
+|---|---|---|
+| `scaleforce[bot]` | This repo's Probot | Orchestration: triage, routing, PR-thread mediation |
+| `claude[bot]` | Anthropic's Claude GitHub App | Substantive AI work: code, deep PR review, spec drafting |
+| `copilot-swe-agent[bot]` | GitHub Copilot coding agent | Parallel coding agent |
+
+Local Claude Code CLI does **not** post on GitHub under the maintainer's identity. Either:
+1. Route GitHub-side activity through the Claude App, or
+2. Authenticate Claude's local `gh` with a separate token belonging to `claude[bot]`.
+
+Commits are always authored by the maintainer's git identity with `Co-Authored-By: Claude <noreply@anthropic.com>` trailers.
+
+### Consequences
+
+- Good: every thread shows who said what, instantly.
+- Good: no extra user account; identities are owned by the `ScaleForceAgency` org.
+- Good: each App can have scoped permissions appropriate to its role.
+- Bad: requires discipline locally — must verify `gh auth status` before any GitHub-side write.
+- Neutral: third-party Apps get the gray `bot` pill, not the purple `AI` pill (that's reserved for GitHub's own products).

--- a/docs/adr/0004-docs-tree-over-github-wiki.md
+++ b/docs/adr/0004-docs-tree-over-github-wiki.md
@@ -1,0 +1,42 @@
+# 0004. Use `docs/` tree instead of GitHub Wiki
+
+- **Status**: accepted
+- **Date**: 2026-04-18
+- **Deciders**: @thomHayner
+- **Tags**: docs, tooling
+
+## Context and Problem Statement
+
+GitHub provides a Wiki feature per repo. It's tempting to use for product docs, but it has structural mismatches with the agent-driven workflow:
+
+- Wikis live in a separate git repo. Not visible in PR diffs.
+- Wikis can't be reviewed alongside code changes.
+- Agents (Claude Code, Copilot) can't easily edit wiki content as part of a PR.
+- Wiki history is not part of the main commit log.
+
+## Decision Drivers
+
+- Docs need to be reviewable in PRs alongside the code that motivates them.
+- Agents need to read and write docs as part of normal PR workflow.
+- Single source of truth for repo-related knowledge.
+
+## Considered Options
+
+- **GitHub Wiki**: native, free, but disconnected from the PR review surface.
+- **`docs/` tree in main repo**: PR-reviewable, agent-editable, version-controlled with the code.
+- **External docs site** (Notion, Confluence): even more disconnected.
+
+## Decision Outcome
+
+Chosen: **`docs/` tree in the main repo**, structured as in [`docs/README.md`](../README.md).
+
+Generated/synthesized agent-readable knowledge lives separately in [`llm-wiki/`](../../llm-wiki/) — also in-repo, but explicitly distinct from the human-curated `docs/` layer.
+
+The GitHub Wiki feature is **disabled** for this repo to avoid confusion.
+
+### Consequences
+
+- Good: docs reviewed in PRs, edited by agents, versioned with code.
+- Good: clear separation between human-authored (`docs/`) and synthesized (`llm-wiki/`) content.
+- Bad: no built-in wiki sidebar / navigation. Mitigation: README index files in each folder.
+- Neutral: contributors who expect a Wiki need to be redirected to `docs/`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,21 @@
+# Architecture Decision Records
+
+Decisions that shape the system, captured in [MADR](https://adr.github.io/madr/) format.
+
+## Conventions
+
+- One file per decision: `NNNN-short-slug.md`, sequentially numbered.
+- Status flows: `proposed` → `accepted` → (optionally) `deprecated` / `superseded by NNNN`.
+- Never delete an ADR. Supersede it with a new one and update the old one's status.
+- Architecture-affecting PRs must add or update an ADR in the same PR.
+
+## Template
+
+See [`template.md`](template.md) — copy it for new ADRs.
+
+## Index
+
+- [0001](0001-record-architecture-decisions.md) — Record architecture decisions
+- [0002](0002-use-feature-dev-main-branch-model.md) — Use `feature → dev → main` branch model
+- [0003](0003-bot-identity-separation.md) — Separate bot identities for orchestration vs. AI work
+- [0004](0004-docs-tree-over-github-wiki.md) — Use `docs/` tree instead of GitHub Wiki

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,45 @@
+# NNNN. {Short title of the decision}
+
+- **Status**: proposed | accepted | deprecated | superseded by [NNNN](NNNN-...md)
+- **Date**: YYYY-MM-DD
+- **Deciders**: @handle, @handle
+- **Tags**: optional, comma, separated
+
+## Context and Problem Statement
+
+What is the situation? What forces are at play? Frame the problem in a way that makes the decision feel inevitable in hindsight.
+
+## Decision Drivers
+
+- driver 1
+- driver 2
+
+## Considered Options
+
+- Option A: ...
+- Option B: ...
+- Option C: ...
+
+## Decision Outcome
+
+Chosen option: **{Option X}**, because {justification}.
+
+### Consequences
+
+- Good: ...
+- Bad: ...
+- Neutral: ...
+
+## Pros and Cons of the Options
+
+### Option A
+- Good: ...
+- Bad: ...
+
+### Option B
+- Good: ...
+- Bad: ...
+
+## More Information
+
+Links, references, related decisions.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,12 @@
+# Architecture
+
+High-level system designs, integration maps, sequence diagrams. Less granular than specs; more durable.
+
+## Suggested files
+
+- `overview.md` — top-level architecture, the diagram with all the boxes
+- `bots-and-identities.md` — who posts as what, and why
+- `integrations.md` — external services (OpenAI, Anthropic, GitHub APIs, etc.)
+- `data-flow.md` — what state lives where
+
+Add when content stabilizes. Architecture decisions get recorded as ADRs in [`../adr/`](../adr/).

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -1,0 +1,27 @@
+# PRDs
+
+Product requirements documents. One file per feature, named `NNN-short-slug.md`.
+
+## Template
+
+```
+# PRD-NNN: {Feature name}
+
+**Status**: draft | in-review | accepted | shipped | superseded
+**Owner**: @handle
+**Related**: spec(s), ADR(s), issue/PR links
+
+## Problem
+What user pain or business need does this address?
+
+## Goals / Non-goals
+What's in scope. What's explicitly out of scope.
+
+## Proposed solution
+High-level shape. Leave implementation details to the spec.
+
+## Success metrics
+How we'll know this worked.
+
+## Open questions
+```

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,23 @@
+# Roadmap
+
+What's next, ordered by priority. Update freely as priorities shift; commit history is the changelog.
+
+## Format
+
+One `YYYY-Qn.md` file per quarter, plus a `now.md` for the current focus.
+
+```
+# Q2 2026
+
+## Now (in flight)
+- ...
+
+## Next (committed, not started)
+- ...
+
+## Later (intent, may shift)
+- ...
+
+## Out of scope this quarter
+- ...
+```

--- a/docs/setup/bot-identity.md
+++ b/docs/setup/bot-identity.md
@@ -1,0 +1,38 @@
+# Bot identity setup
+
+> Decided in [ADR 0003](../adr/0003-bot-identity-separation.md).
+
+## The cast
+
+| Identity | Role | How to install/configure |
+|---|---|---|
+| `scaleforce[bot]` | Orchestration: triage, routing, PR mediation | This repo's Probot. Configure at https://github.com/settings/apps/scaleforce |
+| `claude[bot]` | Substantive AI: code, deep PR review | Install [Claude GitHub App](https://github.com/apps/claude) |
+| `copilot-swe-agent[bot]` | Parallel coding agent | Enable Copilot coding agent in repo settings |
+
+## The maintainer's git config — never let agents change
+
+```sh
+git config user.name  "Thomas Hayner"
+git config user.email "your-email@example.com"
+```
+
+All commits — including those produced by Claude Code — are authored by this identity. AI contribution is recorded via:
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+This keeps "we worked together" visible in the contribution graph and PR history.
+
+## Local Claude Code: identity discipline
+
+When running `claude` locally, before any GitHub-side write (comment, issue, PR), Claude must verify identity with `gh auth status`. If authenticated as the maintainer, do not post under that identity — either:
+
+1. Route through the Claude GitHub App by `@claude`-mentioning in the relevant thread, or
+2. Set `GH_TOKEN` to a token belonging to a bot identity for that shell session, or
+3. Leave a draft in `docs/drafts/` for the maintainer to post manually.
+
+## Why third-party Apps don't get the purple "AI" pill
+
+GitHub reserves the **AI** pill (visible next to Copilot's comments) for its own AI products. Third-party GitHub Apps — including `claude[bot]` and `scaleforce[bot]` — get the gray **bot** pill, same as Vercel, Dependabot, Netlify. This is a GitHub UI policy, not something we can override.

--- a/docs/setup/branching.md
+++ b/docs/setup/branching.md
@@ -1,0 +1,46 @@
+# Branching model
+
+> Decided in [ADR 0002](../adr/0002-use-feature-dev-main-branch-model.md).
+
+## Branches
+
+| Branch | Purpose | Push policy |
+|---|---|---|
+| `main` | Release-only. Always deployable. | Protected. Required reviews. No direct pushes. |
+| `dev` | Working integration branch. | Direct commits OK when iterating. |
+| `feature/*` | Optional isolation for larger work or parallel agent PRs. | Free. |
+
+## Flows
+
+### Quick iteration with the maintainer
+```
+commit directly to dev → ... → release PR dev → main
+```
+
+### Larger feature, or parallel agent work
+```
+branch from dev → feature/foo → PR feature/foo → dev → release PR dev → main
+```
+
+### Hotfix
+Branch from `main`, PR back into `main`, then cherry-pick or merge into `dev`.
+
+## Release
+
+When `dev` is ready to ship:
+
+1. Open PR `dev → main`.
+2. Squash or merge (preserve commit history; squash if `dev` got noisy).
+3. Tag `main` with the release version.
+4. `dev` continues from there.
+
+## Branch protection (configure on GitHub)
+
+`main`:
+- Require PR before merging
+- Require at least 1 approving review
+- Require status checks to pass (CI)
+- Restrict who can push (no one — only PR merges)
+
+`dev`:
+- No restrictions, but warn on force-push

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,33 @@
+# Specs
+
+Technical specifications. One file per spec, named `NNN-short-slug.md`. Specs are paired with an issue or PR — link both ways.
+
+## Template
+
+```
+# SPEC-NNN: {What this spec covers}
+
+**Status**: draft | in-review | accepted | implemented | superseded
+**Owner**: @handle
+**PRD**: link
+**Issue/PR**: links
+**Related ADRs**: links
+
+## Context
+What's the situation? What constraints apply?
+
+## Design
+The actual technical proposal. Diagrams welcome.
+
+## Alternatives considered
+What else was on the table and why it lost.
+
+## Risks
+What could go wrong. Mitigations if any.
+
+## Test plan
+How we'll verify this works.
+
+## Migration / rollout
+If applicable.
+```

--- a/docs/vision/README.md
+++ b/docs/vision/README.md
@@ -1,0 +1,11 @@
+# Vision
+
+The "why." High-level goals, principles, and target users for ScaleForce.
+
+## Files
+
+- `vision.md` — north-star statement *(TODO)*
+- `principles.md` — non-negotiable design principles *(TODO)*
+- `personas.md` — who we're building for *(TODO)*
+
+Add files here when the answers stabilize — don't pre-fill speculatively.

--- a/llm-wiki/README.md
+++ b/llm-wiki/README.md
@@ -1,0 +1,25 @@
+# llm-wiki/
+
+Synthesized, agent-friendly knowledge derived from the messier raw materials in [`docs/`](../docs/) and PR-thread history.
+
+## What goes here vs. `docs/`
+
+| `docs/` | `llm-wiki/` |
+|---|---|
+| Human-curated source-of-truth | Synthesized for agent consumption |
+| PRDs, specs, ADRs, vision | Glossary, agent guides, workflow walkthroughs, durable how-to |
+| Reviewed by the maintainer | Updated by agents as they learn |
+| One file per artifact | Cross-cutting summaries, indexes |
+
+If a piece of knowledge is **decided by the maintainer**, it lives in `docs/`. If it's **synthesized from many sources** for fast agent recall, it lives here.
+
+## Structure
+
+- [`index.md`](index.md) — entry point, links to everything
+- [`glossary.md`](glossary.md) — domain terms, acronyms, conventions
+- [`agents/`](agents/) — per-agent guides (one file per agent identity)
+- [`workflows/`](workflows/) — how common processes work end-to-end (issue lifecycle, PR lifecycle, release)
+
+## Update discipline
+
+When you (any agent) learn something durable that future agents will need, update the relevant file in `llm-wiki/` in the same PR. Don't let knowledge die in a PR thread.

--- a/llm-wiki/agents/claude.md
+++ b/llm-wiki/agents/claude.md
@@ -1,0 +1,31 @@
+# claude[bot]
+
+The substantive AI worker.
+
+## Identity
+
+- GitHub App: official [Claude GitHub App](https://github.com/apps/claude)
+- Bot username: `claude[bot]`
+- Owner: Anthropic (App), installed on `ScaleForceAgency` and personal repos
+
+## How to invoke
+
+- **In any issue/PR/comment**: write `@claude` plus an instruction. The Claude Code Action workflow (`.github/workflows/claude.yml`) picks up the mention and runs Claude Code with full repo context.
+- **Locally**: run `claude` CLI. Local Claude must follow [`../../CLAUDE.md`](../../CLAUDE.md) identity rules — never post on GitHub under the maintainer's identity.
+
+## What it does
+
+- Writes code, opens PRs
+- Performs deep PR review
+- Drafts specs, ADRs, PRDs from rough requirements
+- Answers questions in threads (when `@claude`-mentioned)
+
+## What it does NOT do
+
+- Does not handle triage or routing — that's `scaleforce[bot]`'s job
+- Does not modify `git config user.*`
+- Does not @-mention the maintainer when posting under the maintainer's identity (local CLI case)
+
+## Commit attribution
+
+Commits authored by maintainer's git identity, with `Co-Authored-By: Claude <noreply@anthropic.com>` trailer.

--- a/llm-wiki/agents/copilot.md
+++ b/llm-wiki/agents/copilot.md
@@ -1,0 +1,24 @@
+# copilot-swe-agent[bot]
+
+GitHub's parallel coding agent.
+
+## Identity
+
+- Bot username: `copilot-swe-agent[bot]` (when the coding agent acts)
+- Source: GitHub Copilot, configured in repo settings
+- Distinct from inline Copilot suggestions in the editor — the SWE agent opens PRs
+
+## How to invoke
+
+- Assign an issue to Copilot
+- Use the "Code with Copilot" UI in PR view
+- (Future) `@copilot` mentions if/when supported
+
+## Role in this stack
+
+Often produces a parallel implementation alongside Claude's, especially when the task is well-scoped. The maintainer (or `scaleforce[bot]` mediation) compares outputs and chooses or merges.
+
+## Notes
+
+- Copilot's coding agent is the only third-party identity that GitHub gives the purple **AI** pill — because it's a GitHub product. Claude and ScaleForce get the gray **bot** pill.
+- Copilot follows `.github/copilot-instructions.md` if present (create when needed).

--- a/llm-wiki/agents/scaleforce.md
+++ b/llm-wiki/agents/scaleforce.md
@@ -1,0 +1,32 @@
+# scaleforce[bot]
+
+This repo's Probot. The orchestration layer.
+
+## Identity
+
+- GitHub App: `ScaleForce`
+- Bot username: `scaleforce[bot]`
+- Owner: `ScaleForceAgency` org (when transferred)
+- Source: this repo (`src/`)
+
+## Role
+
+- Triage new issues; apply primary labels
+- Route conversations through intake → duplicate-check → report workflows
+- Mediate PR review threads (planned)
+- Coordinate `@claude` and Copilot interactions in threads (planned)
+
+## What it does NOT do
+
+- Does not write or edit code
+- Does not author commits
+- Does not respond on behalf of the maintainer
+- Does not @-mention itself
+
+## Permissions
+
+See [`app.yml`](../../app.yml). Currently: `issues: write`, `metadata: read`. Will expand to `pull_requests: write` when PR orchestration is added.
+
+## Webhooks subscribed
+
+See [`src/index.ts`](../../src/index.ts). Currently: `issues.opened`, `issue_comment.created`.

--- a/llm-wiki/glossary.md
+++ b/llm-wiki/glossary.md
@@ -1,0 +1,15 @@
+# Glossary
+
+| Term | Meaning |
+|---|---|
+| **ScaleForce** | This project. The orchestration bot and the surrounding agency-pattern conventions. |
+| **ScaleForceAgency** | The GitHub organization that owns the apps and (eventually) the repos. |
+| **The maintainer** | The human in the loop. `thomHayner` on GitHub. |
+| **Orchestration bot** | `scaleforce[bot]` — this repo's Probot. Triages, routes, mediates threads. Does not write code. |
+| **AI dev** | An agent that writes code: `claude[bot]`, `copilot-swe-agent[bot]`. |
+| **Agent** | Any non-human actor: orchestration bot, AI devs, infra bots (Dependabot, Vercel). |
+| **MADR** | Markdown Any Decision Records — the ADR format used in [`docs/adr/`](../docs/adr/). |
+| **PRD** | Product Requirements Document. Lives in [`docs/prd/`](../docs/prd/). |
+| **Spec** | Technical specification. Lives in [`docs/specs/`](../docs/specs/). |
+| **The bot pill** | The gray `bot` label GitHub appends to comments by GitHub Apps. |
+| **The AI pill** | The purple `AI` label reserved for GitHub's own AI products (Copilot). Not available to third parties. |

--- a/llm-wiki/index.md
+++ b/llm-wiki/index.md
@@ -1,0 +1,23 @@
+# LLM Wiki — Index
+
+Start here.
+
+## What is this repo?
+
+ScaleForce is a GitHub-native orchestration bot built on Probot, plus the surrounding "AI agency" pattern: a Probot for orchestration, the Claude GitHub App for substantive AI work, and the Copilot coding agent for parallel PRs — all coordinating with a single human maintainer.
+
+For the *why*, see [`docs/vision/`](../docs/vision/).
+
+## Read this before starting work
+
+1. [`../CLAUDE.md`](../CLAUDE.md) — Claude-specific rules (also relevant for any AI agent).
+2. [`../AGENTS.md`](../AGENTS.md) — universal agent rules.
+3. [`agents/`](agents/) — per-agent identity and behavior guide.
+4. [`workflows/`](workflows/) — how issues, PRs, and releases flow.
+5. [`glossary.md`](glossary.md) — terminology.
+
+## Key references
+
+- Branch model: [`../docs/setup/branching.md`](../docs/setup/branching.md)
+- Bot identities: [`../docs/setup/bot-identity.md`](../docs/setup/bot-identity.md)
+- Decisions: [`../docs/adr/`](../docs/adr/)

--- a/llm-wiki/workflows/issue-lifecycle.md
+++ b/llm-wiki/workflows/issue-lifecycle.md
@@ -1,0 +1,29 @@
+# Issue lifecycle
+
+How a new issue moves from "filed" to "actioned."
+
+```
+opened
+  └─→ scaleforce[bot] adds `intake` label, greets the user
+       └─→ scaleforce[bot] applies primary label (bug/documentation/enhancement/question)
+            └─→ scaleforce[bot] runs duplicate check (labels `unique` or `duplicate`)
+                 └─→ scaleforce[bot] generates official issue report from the .yml template
+                      └─→ maintainer triages → assigns to claude[bot] or copilot, or themselves
+```
+
+Source: [`src/workflows/issueIntake.ts`](../../src/workflows/issueIntake.ts), [`src/workflows/issueWatcher.ts`](../../src/workflows/issueWatcher.ts).
+
+## Labels
+
+| Label | Applied by | Meaning |
+|---|---|---|
+| `intake` | scaleforce[bot] | Issue is in initial triage; AI is gathering info |
+| `bug` / `documentation` / `enhancement` / `question` | scaleforce[bot] | Primary classification |
+| `unique` / `duplicate` | scaleforce[bot] | Result of duplicate check |
+| `good first issue`, `help wanted`, etc. | maintainer | Standard triage |
+
+## When to assign to which agent
+
+- **claude[bot]**: tasks requiring deep context, spec drafting, multi-file changes, architecture decisions.
+- **copilot-swe-agent[bot]**: well-scoped, single-feature tasks where parallel implementation is useful.
+- **maintainer**: anything requiring product judgment or external coordination.

--- a/llm-wiki/workflows/pr-lifecycle.md
+++ b/llm-wiki/workflows/pr-lifecycle.md
@@ -1,0 +1,35 @@
+# PR lifecycle
+
+> Currently aspirational — `scaleforce[bot]` does not yet handle PR events. This file documents the intended workflow and updates as features land.
+
+## Target flow
+
+```
+PR opened (against dev or main)
+  └─→ scaleforce[bot] posts review checklist + requests review from claude[bot]
+       └─→ claude[bot] performs deep review, posts comment thread
+            └─→ if copilot also produced a competing PR: scaleforce[bot] cross-links and summarizes diff
+                 └─→ maintainer reviews synthesis, requests changes or approves
+                      └─→ on approve + checks pass: maintainer merges
+```
+
+## Status checks expected on every PR
+
+- CI: `npm test`, `npm run build`
+- ADR check: if PR touches architecture-affecting paths, must include changes to `docs/adr/`
+- Lint: TypeScript compile + future linter
+
+## Branch targets
+
+- Feature work → PR into `dev`
+- Release → PR `dev` into `main`
+- Hotfix → PR into `main`, then forward-port to `dev`
+
+See [`../../docs/setup/branching.md`](../../docs/setup/branching.md) for detail.
+
+## Conventions
+
+- Title under 70 chars, imperative mood
+- Body uses [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+- One logical change per PR
+- Link spec/ADR/issue

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "AI_Falconiere",
+  "name": "scaleforce-bot",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "AI_Falconiere",
+      "name": "scaleforce-bot",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "AI_Falconiere",
+  "name": "scaleforce-bot",
   "version": "1.0.0",
   "private": true,
-  "description": "An issues wrangler as well as an FAQ and troubleshooting bot agent for AI Hawk",
+  "description": "ScaleForce: a GitHub-native orchestration bot for issue triage, PR review, and AI-agent coordination across the repo.",
   "author": "thomHayner",
   "license": "ISC",
   "homepage": "https://github.com//",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export default (app: Probot) => {
   app.on("issue_comment.created", async (context) => {
     // If the comment was made by this bot, don't rely to self:
     // TODO: make the bot name in next line dynamic
-    if (context.payload.sender.login === "ai-hawk-birdwatcher[bot]") {
+    if (context.payload.sender.login === "scaleforce[bot]") {
       return
     }
     // If the issue is still in 'Intake', go to the 'Issue Intake' workflow:

--- a/src/utils/issuesUtils.ts
+++ b/src/utils/issuesUtils.ts
@@ -15,7 +15,7 @@ export async function fetchMessages(context:any) {
   const data = await response.json();
   const messages = await data.map( (n:any) => {
     return {
-      role: n.user.login === 'ai-hawk-birdwatcher[bot]' ? 'assistant' : 'user',
+      role: n.user.login === 'scaleforce[bot]' ? 'assistant' : 'user',
       content: n.body,
     }
   });
@@ -34,8 +34,8 @@ export async function fetchRepo(context:any) {
 
   const data = await response.json();
   const repoInfo = {
-    name: "LinkedIn_AIHawk_Birdwatcher", // await data.name,
-    owner: "thomHayner", // await data.owner,
+    name: "ScaleForce", // await data.name,
+    owner: "ScaleForceAgency", // await data.owner,
     path: ".github/UserNoAiYesTemplates/ISSUE_TEMPLATE/bug-issue.yml"
   }
 

--- a/src/workflows/issueIntake.ts
+++ b/src/workflows/issueIntake.ts
@@ -23,11 +23,10 @@ export default async function issueOpenedIntake(context: any): Promise<any> {
     // Add the 'intake' Label to the new Issue
     await addLabel("intake", context);
 
-    // Greet the user and direct them to Telegram
+    // Greet the user
+    // TODO: add a community link (Discord/Slack/etc.) once decided.
     const greeting = `Hi there @${context.payload.sender.login}, thanks for opening this issue!\n\
-    Give me a second to to classify the issue, apply labels and see if I have any follow up questions before writing an official report.\n\
-    Also, come join us on Telegram to discuss this issue and other topics with our community!` + `\n` + 
-    `[![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/AIhawkCommunity)`;
+    Give me a second to classify the issue, apply labels, and see if I have any follow up questions before writing an official report.`;
     const greetingParams = context.issue({
       body: greeting,
     });

--- a/src/workflows/issueWatcher.ts
+++ b/src/workflows/issueWatcher.ts
@@ -15,7 +15,7 @@ export default async function issueCommentCreated(context: any): Promise<any> {
     const data = await response.json();
     const messages = await data.map( (n:any) => {
       return {
-        role: n.user.login === 'ai-hawk-birdwatcher[bot]' ? 'assistant' : 'user',
+        role: n.user.login === 'scaleforce[bot]' ? 'assistant' : 'user',
         content: n.body,
       }
     });
@@ -34,7 +34,8 @@ export default async function issueCommentCreated(context: any): Promise<any> {
   ///// If the agent decided on a 'primary label':
   if (aiResponseMessage.includes("PRIMARY_LABEL: ")) {
     const primaryLabel = "bug";
-    await context.octokit.rest.issues.addLabels({ owner: "thomHayner", repo: "AI_HAWK", issue_numbner: "32", labels: [primaryLabel] });
+    // FIXME: hardcoded owner/repo/issue from initial scaffolding; replace with context.issue() and fix `issue_numbner` typo before enabling.
+    await context.octokit.rest.issues.addLabels({ owner: "thomHayner", repo: "scaleforce-github-orchestrator", issue_numbner: "32", labels: [primaryLabel] });
 
     /// Fetch the repo details to feed into Octokit:
     async function fetchRepo() {
@@ -47,8 +48,8 @@ export default async function issueCommentCreated(context: any): Promise<any> {
 
       const data = await response.json();
       const repoInfo = {
-        name: "LinkedIn_AIHawk_Birdwatcher", // await data.name,
-        owner: "thomHayner", // await data.owner,
+        name: "ScaleForce", // await data.name,
+        owner: "ScaleForceAgency", // await data.owner,
         path: ".github/UserNoAiYesTemplates/ISSUE_TEMPLATE/bug-issue.yml"
       }
 


### PR DESCRIPTION
## Summary
- Ships the rename + repo conventions + docs/llm-wiki scaffolding from `dev`.
- Activates the Claude Code Action — `.github/workflows/claude.yml` only fires on `issues`/`issue_comment`/PR-review events when present on the default branch, which is why the smoke test on issue #8 produced no run.

## Contents (4 commits)
- `135acc6` Rename project to ScaleForce
- `a2c1b4b` Add repo conventions and docs/llm-wiki scaffolding
- `4d239c4` Add GitHub templates and Claude Code workflow
- `aeb9c71` Switch claude.yml to CLAUDE_CODE_OAUTH_TOKEN

## Test plan
- [ ] Merge.
- [ ] Re-test wiring by commenting `@claude reply with "pong"` on a fresh issue.
- [ ] Confirm a workflow run appears under Actions and `claude[bot]` replies.