### PR TITLE
Document Copilot reviewer identity; anchor loop on copilot-recursive-review skill; add routing schema

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,7 +2,7 @@
 
 > A GitHub-native orchestration bot built with [Probot](https://github.com/probot/probot) and integrated with [OpenAI](https://platform.openai.com). ScaleForce triages issues, mediates PR review threads between human and AI contributors (Claude, Copilot), and coordinates the agentic dev workflow inside the repo.
 
-Posts as `scaleforce[bot]`. Lives alongside `claude[bot]` (substantive AI work) and `copilot-swe-agent[bot]` (parallel coding agent), with the human maintainer as the final reviewer.
+Posts as `scaleforce[bot]`. Lives alongside `claude[bot]` (substantive AI work) and `copilot-pull-request-reviewer[bot]` (GitHub Copilot PR reviewer — ScaleForce requests and re-requests reviews from it until clean). `copilot-swe-agent[bot]` (Copilot coding agent) is documented but not the primary workflow. The human maintainer is the final reviewer.
 
 ## Setup
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Conventions for **all AI agents** working in this repo (Claude, Copilot, Codex, 
 | `thomHayner` | Human maintainer, final reviewer, merger |
 | `scaleforce[bot]` | Orchestration: triage, routing, PR-thread mediation, label management |
 | `claude[bot]` | Substantive AI work — code, deep PR reviews, spec drafting |
-| `copilot-swe-agent[bot]` | Parallel coding agent, often producing competing PRs |
+| `copilot-pull-request-reviewer[bot]` | GitHub Copilot PR reviewer. `scaleforce[bot]` requests and re-requests reviews from this identity until clean. |
+| `copilot-swe-agent[bot]` | GitHub Copilot coding agent. Available but not the primary workflow; would produce competing PRs alongside Claude. |
 | `dependabot[bot]`, `vercel[bot]`, etc. | Standard infra bots |
 
 Agents have distinct identities **on purpose**. Do not impersonate the maintainer or another agent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,10 @@ This repo runs an "AI agency" pattern with multiple distinct identities. **Knowi
 - **You (Claude)** post on GitHub as `claude[bot]` when invoked via the Claude GitHub App / Claude Code Action. Locally, you may shell to `gh` under whatever account is authenticated — verify with `gh auth status` before posting anything.
 - **The maintainer** is `thomHayner`. They are a human; their comments and reviews are theirs alone.
 - **The orchestration bot** (this repo's Probot) is `scaleforce[bot]`. It handles triage, routing, and PR-thread mediation.
-- **Other agents**: `copilot-swe-agent[bot]`, `dependabot[bot]`, `vercel[bot]`, etc.
+- **GitHub Copilot** surfaces under two bot logins depending on role:
+  - `copilot-pull-request-reviewer[bot]` — Copilot reviewing a PR. This is the active use case; `scaleforce[bot]` requests and re-requests reviews from this identity until it returns clean.
+  - `copilot-swe-agent[bot]` — Copilot's coding agent when it authors a PR. Available but not the primary workflow here.
+- **Other agents**: `dependabot[bot]`, `vercel[bot]`, etc.
 
 ### Comment authoring rules
 

--- a/docs/adr/0003-bot-identity-separation.md
+++ b/docs/adr/0003-bot-identity-separation.md
@@ -31,7 +31,8 @@ Chosen: **Multiple GitHub Apps**, each with its own role and identity:
 |---|---|---|
 | `scaleforce[bot]` | This repo's Probot | Orchestration: triage, routing, PR-thread mediation |
 | `claude[bot]` | Anthropic's Claude GitHub App | Substantive AI work: code, deep PR review, spec drafting |
-| `copilot-swe-agent[bot]` | GitHub Copilot coding agent | Parallel coding agent |
+| `copilot-pull-request-reviewer[bot]` | GitHub Copilot (reviewer role) | PR reviewer; `scaleforce[bot]` requests and re-requests reviews until clean. Active use case. |
+| `copilot-swe-agent[bot]` | GitHub Copilot (coding-agent role) | Parallel coding agent. Documented but not the primary workflow. |
 
 Local Claude Code CLI does **not** post on GitHub under the maintainer's identity. Either:
 1. Route GitHub-side activity through the Claude App, or

--- a/docs/adr/0003-bot-identity-separation.md
+++ b/docs/adr/0003-bot-identity-separation.md
@@ -40,6 +40,21 @@ Local Claude Code CLI does **not** post on GitHub under the maintainer's identit
 
 Commits are always authored by the maintainer's git identity with `Co-Authored-By: Claude <noreply@anthropic.com>` trailers.
 
+### Actor provenance invariant
+
+The identity table above is not descriptive — it is an **operational invariant**. Every GitHub write that is part of orchestration work must be attributable, at the GitHub level, to the identity that owns that work:
+
+- **Orchestration actions run under `scaleforce[bot]`.** Review requests and re-requests, triage replies to review comments, thread resolutions (`resolveReviewThread`), Discussion creation, Issue creation/updates from triage, labels, sticky comments for loop state — all of these are `scaleforce[bot]`'s work and must post under its installation token, never a maintainer PAT or any other identity.
+- **AI code work runs under `claude[bot]`** (or whichever code-agent identity authored it), not under the maintainer. See the rule above about local `gh` auth.
+- **Reviewer output runs under the reviewer's identity.** Copilot's inline comments are `copilot-pull-request-reviewer[bot]`'s; pre-PR review output from a skill is attributed to the corresponding handler identity, not to whoever ran the skill.
+- **The maintainer's identity is reserved for explicit human decisions** — branch-protection approvals, merges, overrides, and judgment calls that deliberately override automation. If a human token is posting routine orchestration output, that is a governance bug to fix, not an acceptable shortcut.
+
+**Why it matters.** The whole identity table is worthless if anyone can post under the wrong name. A `thomHayner`-authored triage reply is indistinguishable, in a thread, from a real maintainer decision — it silently steals the audit trail that [ADR 0003](0003-bot-identity-separation.md) exists to protect.
+
+**Interim exception.** While `scaleforce[bot]` is not yet deployed, orchestration actions taken manually by the maintainer (e.g., running `gh` auth'd as the maintainer to post triage replies) are a known temporary gap. These actions should be migrated to `scaleforce[bot]` the moment the App is live. They are not a precedent.
+
+**How to enforce.** Before merging code that performs a GitHub write, ask: *which identity does this post under at runtime?* If the answer is "whoever ran the script," the code is wrong. `scaleforce[bot]` writes use the Probot / Octokit client built from its installation token; Claude writes use the Claude App's token; the maintainer PAT is not a fallback.
+
 ### Consequences
 
 - Good: every thread shows who said what, instantly.

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -39,17 +39,17 @@ Chosen: **Option B** — `scaleforce[bot]` implements the loop as defined by the
 ### The loop — summary (authoritative detail in the skill)
 
 1. `scaleforce[bot]` requests review from Copilot and records the PR HEAD SHA.
-2. Wait on a cadence picked to keep the Anthropic prompt cache warm (270s default, per the skill's rationale).
+2. Wait on a configurable polling cadence. The skill uses 270s by default, chosen to amortize its own runtime's prompt-cache reuse; the ScaleForce Probot will pick its own cadence based on polling cost, API-rate-limit headroom, and target review latency in its own stack — not coupled to any specific LLM provider's cache behavior.
 3. On each wake, fetch Copilot reviews matching the current HEAD. If none, wait again.
-4. When a matching review arrives, fetch its inline comments. Each comment gets one of the six triage outcomes below.
-5. Apply FIXes (verified via the repo's lint/test/build), open Discussions / Issues for DISCUSS / DEFER, reply on every thread, resolve terminal-state threads, commit, push.
+4. When a matching review arrives, fetch its review threads for the current HEAD. Each thread — which may contain multiple inline comments — gets one of the six triage outcomes below.
+5. Apply FIXes (verified via the repo's lint/test/build), open Discussions / Issues for DISCUSS / DEFER, reply on every triaged thread, resolve terminal-state threads, commit, push.
 6. Re-request review on the new HEAD. Repeat.
 
 All orchestration writes in this loop — the review request, per-thread triage replies, thread resolutions, Discussion and Issue creation — run under `scaleforce[bot]`'s installation token. The maintainer PAT is not a fallback. See [ADR 0003 § Actor provenance invariant](0003-bot-identity-separation.md#actor-provenance-invariant).
 
 ### The terminal-state invariant
 
-Every Copilot thread must end the loop in one of six states. This is the skill's central contract:
+Every Copilot review thread must end the loop in one of six states. GitHub's resolvable unit is the thread, so triage and terminal-state enforcement are both defined at the thread level (a thread may contain multiple inline comments; the whole thread takes one outcome). This is the skill's central contract:
 
 | Triage | Reply on thread | Side effect | Thread state |
 |---|---|---|---|
@@ -62,7 +62,7 @@ Every Copilot thread must end the loop in one of six states. This is the skill's
 
 **DISCUSS vs DEFER** is about the *shape* of the follow-up, not its importance: open-ended question → Discussion; concrete scoped work → Issue. If Discussions are disabled on the repo, fold DISCUSS into DEFER with a `question`/`discussion` label.
 
-`HUMAN-PAUSE` is the only escape hatch and it should be rare. If the bot uses it for >~10% of comments, something in the loop isn't working.
+`HUMAN-PAUSE` is the only escape hatch and it should be rare. If the bot uses it on >~10% of threads, something in the loop isn't working.
 
 ### Termination
 
@@ -71,7 +71,7 @@ The loop stops when **any** of these is true:
 - Zero unresolved Copilot threads on the current HEAD after a fresh review.
 - A `HUMAN-PAUSE` was raised this round.
 - The maintainer says stop / takes over.
-- **Same class of comment recurs for 3 rounds in a row with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve; it replaces the 7-iteration hard cap from the prior ADR version. Pattern-based detection catches the actual pathology (we're not converging) rather than a proxy for it.
+- **Same class of thread recurs for 3 rounds in a row with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve; it replaces the 7-iteration hard cap from the prior ADR version. Pattern-based detection catches the actual pathology (we're not converging) rather than a proxy for it.
 
 ### Non-Copilot bot traffic
 
@@ -86,9 +86,9 @@ The loop is done only when **all** bot threads, not just Copilot's, are in a ter
 
 ### Durable state
 
-Probot is stateless across events. The loop's state — round number, HEAD SHA, per-comment triage decisions, commits made — must be reconstructible from a mix of GitHub API queries and persistent scratch (a label on the PR, a sticky comment, or a stored counter keyed by PR number). The skill encodes this via `TodoWrite` for local use; the ScaleForce implementation will choose a GitHub-durable equivalent when it's built.
+Probot is stateless across events. The loop's state — round number, HEAD SHA, per-thread triage decisions, commits made — must be reconstructible from a mix of GitHub API queries and persistent scratch (a label on the PR, a sticky comment, or a stored counter keyed by PR number). The skill encodes this via `TodoWrite` for local use; the ScaleForce implementation will choose a GitHub-durable equivalent when it's built.
 
-Critically: "zero comments on this HEAD" is not inferable from the `pull_request_review` webhook payload — that event doesn't carry an inline-comment count. `scaleforce[bot]` must compute it by fetching the review's inline comments — `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments` — counting the returned items, and filtering to threads tied to the current HEAD SHA.
+Critically: "zero unresolved threads on this HEAD" is not inferable from the `pull_request_review` webhook payload — that event carries neither inline-comment counts nor thread resolution state. `scaleforce[bot]` must compute it by fetching the review's inline comments (`GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments`) plus the PR's review threads via the GraphQL `pullRequest.reviewThreads` field (for `isResolved`), then filtering to threads tied to the current HEAD SHA.
 
 ### Consequences
 

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -93,7 +93,7 @@ Critically: "zero unresolved threads on this HEAD" is not inferable from the `pu
 ### Consequences
 
 - Good: aligns with working implementation rather than reinventing it. Skill and ADR stay in sync by construction.
-- Good: six-outcome triage gives Discussions and Issues a consistent vocabulary across phases (see forthcoming ADR 0007 on routing).
+- Good: six-outcome triage gives Discussions and Issues a consistent vocabulary across phases (see [ADR 0007](0007-github-function-routing.md) on routing).
 - Good: pattern-based non-convergence detection is more sensitive than a round cap — catches stuck loops earlier without terminating productive ones.
 - Good: other-bots handling collapses into the same taxonomy, so ScaleForce doesn't need a separate code path per bot.
 - Bad: authoritative loop definition lives in a different repo (`ai-skill-builder-library`). If the skill moves or is renamed, this ADR needs an update. Mitigation: reference by skill name, not path, and keep the name stable.

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -45,6 +45,8 @@ Chosen: **Option B** — `scaleforce[bot]` implements the loop as defined by the
 5. Apply FIXes (verified via the repo's lint/test/build), open Discussions / Issues for DISCUSS / DEFER, reply on every thread, resolve terminal-state threads, commit, push.
 6. Re-request review on the new HEAD. Repeat.
 
+All orchestration writes in this loop — the review request, per-thread triage replies, thread resolutions, Discussion and Issue creation — run under `scaleforce[bot]`'s installation token. The maintainer PAT is not a fallback. See [ADR 0003 § Actor provenance invariant](0003-bot-identity-separation.md#actor-provenance-invariant).
+
 ### The terminal-state invariant
 
 Every Copilot thread must end the loop in one of six states. This is the skill's central contract:

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -1,0 +1,80 @@
+# 0005. Copilot-reviewer loop: zero-comments exit, PR-author-owned triage
+
+- **Status**: proposed
+- **Date**: 2026-04-19
+- **Deciders**: @thomHayner
+- **Tags**: bots, review, orchestration, copilot
+
+## Context and Problem Statement
+
+`scaleforce[bot]` orchestrates PR review in this repo. GitHub Copilot, assigned as a reviewer on PRs, posts reviews as `copilot-pull-request-reviewer[bot]`. Two questions need settled answers before probot can implement the re-request loop:
+
+1. **What signals "clean"** — when does ScaleForce stop re-requesting review from Copilot?
+2. **Who handles Copilot's review comments** — when Copilot leaves suggestions, whose job is it to triage and apply fixes?
+
+Both are orchestration rules probot will enforce automatically, so they need to be explicit and stable.
+
+## Decision Drivers
+
+- Copilot's reviewer identity (`copilot-pull-request-reviewer[bot]`) is restricted by GitHub/Microsoft to `COMMENTED` reviews — it cannot post an `APPROVED` state. Any exit condition that waits for approval would loop forever.
+- Copilot reviews; it does not write fixes. Someone else has to triage the suggestions and decide how to respond.
+- This repo may gain additional code agents (Codex, others) over time. The routing rule should extend without a rewrite.
+- Each identity in the agency should own its own work — the PR author is the actor best positioned to judge Copilot's suggestions against the change they authored.
+
+## Considered Options
+
+- **Option A: exit on `APPROVED`.** Standard GitHub review semantics. Rejected because Copilot can't ever reach this state.
+- **Option B: exit on `COMMENTED` with zero review comments.** Treats "nothing to say" as approval-equivalent for the purposes of the loop.
+- **Option C: exit on a maintainer override only.** Always surface Copilot's review to the maintainer; never auto-exit.
+
+For fix-routing:
+- **Option X: always route to `claude[bot]`.** Simple; works while Claude is the only non-human code agent.
+- **Option Y: always route to the maintainer.** Low automation.
+- **Option Z: route based on PR author.** Claude's PRs get `@claude`, the maintainer's PRs get the maintainer, future agents get themselves.
+
+## Decision Outcome
+
+Chosen:
+
+- **Exit condition: Option B** — Copilot's review comes back with zero review comments (i.e. `COMMENTED` state, empty comment list). This is "clean."
+- **Fix routing: Option Z** — `scaleforce[bot]` pings the PR author when Copilot leaves comments. The PR author owns triage.
+
+### The loop, explicitly
+
+1. `scaleforce[bot]` requests review from Copilot on a PR.
+2. On `pull_request_review` with `review.user.login === "copilot-pull-request-reviewer[bot]"`:
+   - **Zero review comments** → exit. PR is clean as far as Copilot is concerned.
+   - **One or more review comments** → ping the PR author to triage (loops 1–6), or escalate to the maintainer (loop 7+).
+3. PR author (or maintainer on escalation) triages Copilot's suggestions: accept and fix, modify, or reject inline with rationale.
+4. PR author pushes fixes and signals `scaleforce[bot]` to re-request review from Copilot.
+5. Recurse until exit (zero comments) or escalation (loop 7).
+
+### Max iterations
+
+The loop caps at **7 iterations**. `scaleforce[bot]` tracks iteration count per PR (e.g. as a label, a sticky comment, or a stored counter). On the 7th review-with-comments, the routing flips from PR author to maintainer — this is the signal that author/Copilot are not converging and a human needs to break the tie (adjust scope, override a Copilot suggestion, or close the PR).
+
+Rationale for seven: high enough that normal back-and-forth never trips it (most PRs converge in 1–2 loops), low enough that a runaway loop gets caught before it wastes real time or API quota.
+
+### Routing table
+
+| PR author | `scaleforce[bot]` pings |
+|---|---|
+| `claude[bot]` | `@claude` in the PR thread |
+| `thomHayner` (maintainer) | the maintainer directly |
+| future code agents (e.g. Codex) | that agent's handle |
+
+### Consequences
+
+- Good: loop terminates deterministically — no waiting for a state Copilot cannot produce.
+- Good: routing extends to new code agents by adding a row, not changing logic.
+- Good: the 7-iteration cap bounds worst-case cost and guarantees a human gets pulled in on pathological loops.
+- Good: preserves the "each identity owns its work" principle from [ADR 0003](0003-bot-identity-separation.md).
+- Bad: zero-comments-as-clean is a convention, not a formal approval. A human reviewer is still required before merge to `main` per the branch model ([ADR 0002](0002-use-feature-dev-main-branch-model.md)).
+- Neutral: if Copilot ever gains the ability to approve (or GitHub relaxes the restriction), the exit condition should be revisited — at that point `APPROVED` becomes the stronger signal.
+
+## More Information
+
+- [`llm-wiki/agents/copilot.md`](../../llm-wiki/agents/copilot.md) — agent-facing description of the loop.
+- [ADR 0003](0003-bot-identity-separation.md) — identity separation rationale.
+- GitHub REST: `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["Copilot"]`.
+- Webhook: `pull_request_review` — dispatch on `review.user.login`.

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -1,4 +1,4 @@
-# 0005. Copilot-reviewer loop: zero-comments exit, PR-author-owned triage
+# 0005. Copilot-reviewer loop: terminal-state invariant, triage taxonomy, anchor on `copilot-recursive-review` skill
 
 - **Status**: proposed
 - **Date**: 2026-04-19
@@ -7,74 +7,100 @@
 
 ## Context and Problem Statement
 
-`scaleforce[bot]` orchestrates PR review in this repo. GitHub Copilot, assigned as a reviewer on PRs, posts reviews as `copilot-pull-request-reviewer[bot]`. Two questions need settled answers before probot can implement the re-request loop:
+`scaleforce[bot]` orchestrates PR review. GitHub Copilot (login `copilot-pull-request-reviewer[bot]`) is the only AI that can be assigned via `requested_reviewers` — empirically verified; GitHub silently rejects every other App. Copilot is also restricted to `COMMENTED` reviews by GitHub/Microsoft, so branch protection approvals are never satisfied by a bot (confirmed in GitHub's [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) — only eligible human reviewers can issue counting `APPROVED` reviews).
 
-1. **What signals "clean"** — when does ScaleForce stop re-requesting review from Copilot?
-2. **Who handles Copilot's review comments** — when Copilot leaves suggestions, whose job is it to triage and apply fixes?
+We need explicit rules for the loop `scaleforce[bot]` will drive when Copilot reviews a PR:
 
-Both are orchestration rules probot will enforce automatically, so they need to be explicit and stable.
+1. **What signals "clean"** — when does ScaleForce stop re-requesting review?
+2. **Who handles Copilot's comments** — triage responsibility and terminal states.
+3. **How does the loop avoid running forever** — safety valve on non-convergence.
+4. **How do we handle non-Copilot bot comments** on the same PR — Vercel, CodeRabbit, Sentry, etc.
+
+A prior version of this ADR proposed a simple "zero comments = clean / 7-iteration hard cap / PR-author triage" model. That's been superseded by the `copilot-recursive-review` skill (lives in `ai-skill-builder-library/skills/software-development/copilot-recursive-review/`), which encodes a richer model from a working two-round prototype. This ADR captures the decision to anchor `scaleforce[bot]`'s implementation on that skill.
 
 ## Decision Drivers
 
-- Copilot's reviewer identity (`copilot-pull-request-reviewer[bot]`) is restricted by GitHub/Microsoft to `COMMENTED` reviews — it cannot post an `APPROVED` state. Any exit condition that waits for approval would loop forever.
-- Copilot reviews; it does not write fixes. Someone else has to triage the suggestions and decide how to respond.
-- This repo may gain additional code agents (Codex, others) over time. The routing rule should extend without a rewrite.
-- Each identity in the agency should own its own work — the PR author is the actor best positioned to judge Copilot's suggestions against the change they authored.
+- The skill is already written and has been run successfully end-to-end. Reinventing the loop in ScaleForce would diverge from a working implementation.
+- "Zero comments" is too coarse — real reviews produce a mix of legitimate concerns, false positives, scope-creep suggestions, and noise. Each needs a different disposition.
+- Round counting is a weak proxy for non-convergence. A PR can loop 2 rounds and be stuck; another can loop 10 productive rounds. Pattern-based termination beats counter-based.
+- Copilot is not the only bot on a typical PR. The orchestration model has to absorb Vercel previews, CodeRabbit, Sentry, Renovate, and in-house agentic bots — not just Copilot.
+- Probot is stateless-per-event; the loop's state must be reconstructible from GitHub + persisted scratch, not held in process memory.
 
 ## Considered Options
 
-- **Option A: exit on `APPROVED`.** Standard GitHub review semantics. Rejected because Copilot can't ever reach this state.
-- **Option B: exit on `COMMENTED` with zero review comments.** Treats "nothing to say" as approval-equivalent for the purposes of the loop.
-- **Option C: exit on a maintainer override only.** Always surface Copilot's review to the maintainer; never auto-exit.
-
-For fix-routing:
-- **Option X: always route to `claude[bot]`.** Simple; works while Claude is the only non-human code agent.
-- **Option Y: always route to the maintainer.** Low automation.
-- **Option Z: route based on PR author.** Claude's PRs get `@claude`, the maintainer's PRs get the maintainer, future agents get themselves.
+- **Option A** (original ADR 0005): zero-comments exit, 7-iteration hard cap, PR-author triage, Copilot-only.
+- **Option B** (this ADR): anchor on `copilot-recursive-review` skill — terminal-state invariant with 6-outcome triage, non-convergence pattern detection as the safety valve, skill's "other bots" section for non-Copilot traffic.
+- **Option C**: write a new orchestration model from scratch inside ScaleForce. Rejected — duplicates working code and invites drift.
 
 ## Decision Outcome
 
-Chosen:
+Chosen: **Option B** — `scaleforce[bot]` implements the loop as defined by the `copilot-recursive-review` skill. The skill is the authoritative definition; this ADR summarizes the contract and captures the decision.
 
-- **Exit condition: Option B** — Copilot's review comes back with zero review comments (i.e. `COMMENTED` state, empty comment list). This is "clean."
-- **Fix routing: Option Z** — `scaleforce[bot]` pings the PR author when Copilot leaves comments. The PR author owns triage.
+### The loop — summary (authoritative detail in the skill)
 
-### The loop, explicitly
+1. `scaleforce[bot]` requests review from Copilot and records the PR HEAD SHA.
+2. Wait on a cadence picked to keep the Anthropic prompt cache warm (270s default, per the skill's rationale).
+3. On each wake, fetch Copilot reviews matching the current HEAD. If none, wait again.
+4. When a matching review arrives, fetch its inline comments. Each comment gets one of the six triage outcomes below.
+5. Apply FIXes (verified via the repo's lint/test/build), open Discussions / Issues for DISCUSS / DEFER, reply on every thread, resolve terminal-state threads, commit, push.
+6. Re-request review on the new HEAD. Repeat.
 
-1. `scaleforce[bot]` requests review from Copilot on a PR.
-2. On `pull_request_review` with `review.user.login === "copilot-pull-request-reviewer[bot]"`:
-   - **Zero review comments** → exit. PR is clean as far as Copilot is concerned.
-   - **One or more review comments** → ping the PR author to triage (loops 1–6), or escalate to the maintainer (loop 7+).
-3. PR author (or maintainer on escalation) triages Copilot's suggestions: accept and fix, modify, or reject inline with rationale.
-4. PR author pushes fixes and signals `scaleforce[bot]` to re-request review from Copilot.
-5. Recurse until exit (zero comments) or escalation (loop 7).
+### The terminal-state invariant
 
-### Max iterations
+Every Copilot thread must end the loop in one of six states. This is the skill's central contract:
 
-The loop caps at **7 iterations**. `scaleforce[bot]` tracks iteration count per PR (e.g. as a label, a sticky comment, or a stored counter). On the 7th review-with-comments, the routing flips from PR author to maintainer — this is the signal that author/Copilot are not converging and a human needs to break the tie (adjust scope, override a Copilot suggestion, or close the PR).
+| Triage | Reply on thread | Side effect | Thread state |
+|---|---|---|---|
+| **FIX** | "Applied in `<sha>`: <what changed, where, how verified>" | Commit pushed to PR branch | resolved |
+| **REJECT** | "Not changing: <2–4 sentence justification citing rule/file/convention>" | none | resolved |
+| **DISCUSS** | "Opened <Discussion link> to track this design question; resolving." | New GitHub Discussion + backlink | resolved |
+| **DEFER** | "Legitimate but out of scope; filed <Issue link> to track; resolving." | New GitHub Issue + backlink | resolved |
+| **NOISE** | "Skipping — <duplicate / stale / opted-out / auto-generated non-signal>." | none | resolved |
+| **HUMAN-PAUSE** | "Pausing here for human review — <reason>" | Surface to user; loop halts | **left open**, called out in final report |
 
-Rationale for seven: high enough that normal back-and-forth never trips it (most PRs converge in 1–2 loops), low enough that a runaway loop gets caught before it wastes real time or API quota.
+**DISCUSS vs DEFER** is about the *shape* of the follow-up, not its importance: open-ended question → Discussion; concrete scoped work → Issue. If Discussions are disabled on the repo, fold DISCUSS into DEFER with a `question`/`discussion` label.
 
-### Routing table
+`HUMAN-PAUSE` is the only escape hatch and it should be rare. If the bot uses it for >~10% of comments, something in the loop isn't working.
 
-| PR author | `scaleforce[bot]` pings |
-|---|---|
-| `claude[bot]` | `@claude` in the PR thread |
-| `thomHayner` (maintainer) | the maintainer directly |
-| future code agents (e.g. Codex) | that agent's handle |
+### Termination
+
+The loop stops when **any** of these is true:
+
+- Zero unresolved Copilot threads on the current HEAD after a fresh review.
+- A `HUMAN-PAUSE` was raised this round.
+- The maintainer says stop / takes over.
+- **Same class of comment recurs for 3 rounds in a row with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve; it replaces the 7-iteration hard cap from the prior ADR version. Pattern-based detection catches the actual pathology (we're not converging) rather than a proxy for it.
+
+### Non-Copilot bot traffic
+
+Other bots comment on the same PR — Vercel previews, CodeRabbit, Renovate, Sentry, in-house agentic bots. Same six-outcome triage taxonomy applies to their threads. `FIX` has four concrete shapes when responding to another bot:
+
+1. Fix on our end (edit our code/config, push, the bot re-runs and re-posts).
+2. Agent-to-agent directive (e.g. `@coderabbitai resolve` for bots that accept structured in-thread commands).
+3. Trigger an external action (re-run a workflow, redeploy).
+4. Acknowledge-and-resolve (bot announced something with no action needed).
+
+The loop is done only when **all** bot threads, not just Copilot's, are in a terminal state. Detail in the skill's "Other bots on the same PR" section.
+
+### Durable state
+
+Probot is stateless across events. The loop's state — round number, HEAD SHA, per-comment triage decisions, commits made — must be reconstructible from a mix of GitHub API queries and persistent scratch (a label on the PR, a sticky comment, or a stored counter keyed by PR number). The skill encodes this via `TodoWrite` for local use; the ScaleForce implementation will choose a GitHub-durable equivalent when it's built.
+
+Critically: "zero comments on this HEAD" is not inferable from the `pull_request_review` webhook payload — that event doesn't carry an inline-comment count. `scaleforce[bot]` must compute it by fetching the review's inline comments — `GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments` — counting the returned items, and filtering to threads tied to the current HEAD SHA.
 
 ### Consequences
 
-- Good: loop terminates deterministically — no waiting for a state Copilot cannot produce.
-- Good: routing extends to new code agents by adding a row, not changing logic.
-- Good: the 7-iteration cap bounds worst-case cost and guarantees a human gets pulled in on pathological loops.
-- Good: preserves the "each identity owns its work" principle from [ADR 0003](0003-bot-identity-separation.md).
-- Bad: zero-comments-as-clean is a convention, not a formal approval. A human reviewer is still required before merge to `main` per the branch model ([ADR 0002](0002-use-feature-dev-main-branch-model.md)).
-- Neutral: if Copilot ever gains the ability to approve (or GitHub relaxes the restriction), the exit condition should be revisited — at that point `APPROVED` becomes the stronger signal.
+- Good: aligns with working implementation rather than reinventing it. Skill and ADR stay in sync by construction.
+- Good: six-outcome triage gives Discussions and Issues a consistent vocabulary across phases (see forthcoming ADR 0007 on routing).
+- Good: pattern-based non-convergence detection is more sensitive than a round cap — catches stuck loops earlier without terminating productive ones.
+- Good: other-bots handling collapses into the same taxonomy, so ScaleForce doesn't need a separate code path per bot.
+- Bad: authoritative loop definition lives in a different repo (`ai-skill-builder-library`). If the skill moves or is renamed, this ADR needs an update. Mitigation: reference by skill name, not path, and keep the name stable.
+- Neutral: human approval remains the only branch-protection merge gate. The loop produces advisory signal; it does not unblock merge.
 
 ## More Information
 
-- [`llm-wiki/agents/copilot.md`](../../llm-wiki/agents/copilot.md) — agent-facing description of the loop.
-- [ADR 0003](0003-bot-identity-separation.md) — identity separation rationale.
-- GitHub REST: `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["Copilot"]`.
-- Webhook: `pull_request_review` — dispatch on `review.user.login`.
+- [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill — authoritative loop definition (path at time of writing: `skills/software-development/copilot-recursive-review/SKILL.md`).
+- [ADR 0003](0003-bot-identity-separation.md) — identity separation, where the bot logins are enumerated.
+- [ADR 0007](0007-github-function-routing.md) — the routing schema that decides *when* to invoke this loop.
+- [`llm-wiki/agents/copilot.md`](../../llm-wiki/agents/copilot.md) — agent-facing summary.
+- GitHub REST: `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["copilot-pull-request-reviewer[bot]"]`. Webhook: `pull_request_review` → dispatch on `review.user.login`.

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -7,7 +7,7 @@
 
 ## Context and Problem Statement
 
-`scaleforce[bot]` orchestrates PR review. GitHub Copilot (login `copilot-pull-request-reviewer[bot]`) is the only AI that can be assigned via `requested_reviewers` — empirically verified; GitHub silently rejects every other App. Copilot is also restricted to `COMMENTED` reviews by GitHub/Microsoft, so branch protection approvals are never satisfied by a bot (confirmed in GitHub's [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) — only eligible human reviewers can issue counting `APPROVED` reviews).
+`scaleforce[bot]` orchestrates PR review. GitHub Copilot (login `copilot-pull-request-reviewer[bot]`) is the only AI that can be assigned via `requested_reviewers` — empirically verified; GitHub silently rejects every other App. Copilot is also restricted to `COMMENTED` reviews by GitHub/Microsoft, so branch protection approvals are never satisfied by a bot (confirmed in GitHub's [About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches) — only eligible human reviewers can issue `APPROVED` reviews that count toward branch protection).
 
 We need explicit rules for the loop `scaleforce[bot]` will drive when Copilot reviews a PR:
 

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -162,6 +162,6 @@ No handler in the schema can issue an `APPROVED` review. Branch protection appro
 ## More Information
 
 - [ADR 0003](0003-bot-identity-separation.md) — identity separation; mechanism-rail handler names map to these logins.
-- [ADR 0005](0005-copilot-reviewer-loop.md) — the `pr-reviews[copilot]` loop contract (terminal-state invariant, triage taxonomy, non-convergence rule).
-- [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill — authoritative definition of the `pr-reviews[copilot]` mechanism.
+- [ADR 0005](0005-copilot-reviewer-loop.md) — the Copilot PR-reviews loop contract (terminal-state invariant, triage taxonomy, non-convergence rule) — invoked when `copilot` appears in the `orchestrator.slots.pr-reviews` list.
+- [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill — authoritative definition of the loop that runs for a `copilot` entry in `orchestrator.slots.pr-reviews`.
 - [ADR 0002](0002-use-feature-dev-main-branch-model.md) — branch model; clarifies that human approval is the merge gate regardless of routing.

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -157,7 +157,7 @@ No handler in the schema can issue an `APPROVED` review. Branch protection appro
 ### Option C: cascade (chosen)
 - Good: combines A's brevity for homogeneous cases with B's expressiveness for mixed ones.
 - Good: mirrors how design tokens and CSS custom properties work — familiar mental model.
-- Bad: users have to know the default-plus-override pattern. Mitigated by the config being small (7 slots).
+- Bad: users have to know the default-plus-override pattern. Mitigated by the config being small (6 slots).
 
 ## More Information
 

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -1,0 +1,157 @@
+# 0007. GitHub function routing: cascading defaults with per-function overrides
+
+- **Status**: proposed
+- **Date**: 2026-04-19
+- **Deciders**: @thomHayner
+- **Tags**: routing, orchestration, bots, configuration
+
+## Context and Problem Statement
+
+`scaleforce[bot]` orchestrates a growing number of GitHub-facing functions — issue intake, discussions, documentation edits, PR prep, PR reviews, and so on. Each function can, in principle, be owned by a different agent: Claude, Copilot, Codex when added, or the maintainer. We want to express ownership like a design-system token: **set one default, override by slot where needed**, and extend as new agents join without rewriting any routing logic.
+
+Empirical constraints from earlier decisions narrow what's assignable:
+
+- Only `copilot-pull-request-reviewer[bot]` can be attached to a PR via `requested_reviewers` (see [ADR 0003](0003-bot-identity-separation.md) and [ADR 0005](0005-copilot-reviewer-loop.md)). GitHub silently rejects every other App — `claude[bot]` and `scaleforce[bot]` both fail when assigned this way.
+- No bot can post an `APPROVED` review. Branch-protection approvals require a human ([GitHub docs: About protected branches](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches)).
+- For functions *other* than PR reviews (issues, discussions, docs, PR prep), any agent that can be pinged in a comment or run as a skill/action can own the function — the constraint is mechanism, not identity.
+
+So the routing schema needs two distinct "rails":
+
+- **Dispatch rail** — who gets the work. A default handler, plus per-function overrides.
+- **Mechanism rail** — how that handler is actually invoked for a given function (reviewer assignment, `@mention`, skill invocation, GitHub Action, etc.). Constrained by GitHub.
+
+## Decision Drivers
+
+- Extending to a new agent should be a config change, not a code change.
+- A single "whole agency" theme ("Claude runs everything", "Copilot runs everything") should be expressible in one line.
+- One-off overrides ("Copilot for PR reviews, Claude for everything else") should be expressible without forking the default.
+- The schema must respect hard GitHub constraints — it should not let a user configure `claude[bot]` as a PR reviewer, because that silently does nothing.
+- The six-outcome triage taxonomy from [ADR 0005](0005-copilot-reviewer-loop.md) (FIX / REJECT / DISCUSS / DEFER / NOISE / HUMAN-PAUSE) should be shared vocabulary across functions so Discussions and Issues stay consistent.
+
+## Considered Options
+
+- **Option A: one theme key.** Single setting like `orchestrator: claude`. Clean, but can't express "mostly Claude, but Copilot for PR reviews."
+- **Option B: flat list of per-function handlers.** Every function names its handler; no default. Verbose; changing the whole agency means rewriting N lines.
+- **Option C** *(this ADR)*: **cascade — one default, per-function overrides**. Like CSS: set `--orchestrator: claude`, override slots where needed. Easy to read one-line configs and easy to do surgical overrides.
+
+## Decision Outcome
+
+Chosen: **Option C**, cascading defaults.
+
+### The schema
+
+```yaml
+orchestrator:
+  # Default handler for any function not listed below.
+  default: claude
+
+  # Per-function overrides. Each function is a "slot" you can override.
+  slots:
+    bug-reports: claude          # subset of issues; same mechanism
+    issues: claude
+    discussions: claude
+    documentation: claude
+    pr-prep: claude
+    pr-reviews:                  # multi-handler slot (see below)
+      - copilot                  # GitHub reviewer (the only assignable AI)
+      - claude-preflight         # skill-based pre-PR review during pr-prep
+```
+
+Terse form for "whole agency" configs:
+
+```yaml
+orchestrator:
+  default: claude   # everything Claude-owned; pr-reviews still uses Copilot via the constraint below
+```
+
+### The seven functions (slots)
+
+| Slot | What it covers | Default handler mechanism |
+|---|---|---|
+| `bug-reports` | Subset of `issues`. Labeled / templated as bug. | `@mention` or skill on issue open. |
+| `issues` | Non-bug issue intake, triage, cross-linking. | `@mention` or skill on issue open. |
+| `discussions` | Answering / routing GitHub Discussions. | `@mention` or skill on discussion create. |
+| `documentation` | Doc PRs opened against `docs/` or `llm-wiki/`. | Skill invoked by `scaleforce[bot]`. |
+| `pr-prep` | Pre-PR work: branch creation, commit crafting, draft PR body, optional pre-review. | Skill or action before PR opens. |
+| `pr-reviews` | Post-PR-open review by the reviewer cast. | Copilot assigned via `requested_reviewers`; other reviewers run as skills. See [ADR 0005](0005-copilot-reviewer-loop.md). |
+| *(not a slot)* `pr-triage` | Routing incoming PR events, requesting reviews, applying labels, dispatching to `pr-reviews`. | **Inherent to `scaleforce[bot]`** — not delegated. |
+
+Two intentional choices above:
+
+1. **`bug-reports` is a subset of `issues`**, not a sibling. It's kept as its own slot because bug triage often warrants a different handler (e.g. Copilot if bugs are typically in code; Claude if they're typically in docs or UX). Default is to inherit `issues`.
+2. **`pr-triage` is not a slot.** It's `scaleforce[bot]`'s own job — parsing webhook events, applying labels, requesting reviews, dispatching to the `pr-reviews` cast. Making it overridable would mean letting another agent take over ScaleForce's role, which is a different decision.
+
+### The `pr-reviews` slot is a list, not a scalar
+
+Because:
+
+- GitHub only allows **one** AI App (Copilot) as a `requested_reviewers` entry. Other agents can review but not via that mechanism.
+- Pre-PR reviews (running Claude's code review skill during `pr-prep`) are still "reviews" in the workflow sense — they should appear in the cast.
+- Future additions (a second reviewer App, a human-gate bot) should be add-a-line.
+
+Schema allows:
+
+```yaml
+pr-reviews:
+  - copilot                 # GitHub-reviewer mechanism; the recursive loop from ADR 0005
+  - claude-preflight        # skill mechanism; runs in pr-prep before PR opens
+```
+
+`scaleforce[bot]` consults the list and dispatches each entry through its declared mechanism. The `copilot` entry triggers the loop described in [ADR 0005](0005-copilot-reviewer-loop.md).
+
+### Mechanism rail — what each handler name resolves to
+
+| Handler name | Mechanism | Valid slots |
+|---|---|---|
+| `claude` | `@mention` of `@claude` + Claude Code Action workflow | all except `pr-reviews[reviewer]` |
+| `claude-preflight` | Skill run during `pr-prep` (no `@mention`) | `pr-reviews` only (as preflight) |
+| `copilot` | `requested_reviewers` + `pull_request_review` webhook loop | `pr-reviews` only (GitHub constraint) |
+| `maintainer` | Ping `@thomHayner` | all |
+| *(future)* `codex` | `@codex` mention or dedicated action | all except `pr-reviews[reviewer]` until GitHub whitelists |
+
+Constraint enforcement: `scaleforce[bot]` rejects config that puts a non-assignable handler into `pr-reviews` as a reviewer entry (would silently no-op at runtime otherwise). Preflight entries are fine regardless of App whitelisting since they don't touch `requested_reviewers`.
+
+### Shared vocabulary across slots
+
+All slots that produce structured output (issues triage, PR reviews, discussions) use the same six-outcome taxonomy from [ADR 0005](0005-copilot-reviewer-loop.md):
+
+**FIX / REJECT / DISCUSS / DEFER / NOISE / HUMAN-PAUSE**
+
+That means an issue triaged with `DEFER` looks, in its metadata, the same as a PR-review comment triaged `DEFER`. Downstream automation (labels, Discussions, dashboards) can key off one taxonomy instead of per-slot jargon.
+
+### Approval authority — does not move
+
+No handler in the schema can issue an `APPROVED` review. Branch protection approvals remain humans-only. The schema names *who runs the work*, not *who approves the merge*. This is intentional and explicit so a user reading the config doesn't assume "I set `pr-reviews: copilot` and now Copilot can approve merges."
+
+### Consequences
+
+- Good: a new agent joins by adding a row to the mechanism table and optionally a slot override. No code change in the router.
+- Good: "whole-agency" configs stay one line; surgical overrides stay readable.
+- Good: shared FIX/REJECT/DISCUSS/DEFER/NOISE/HUMAN-PAUSE vocabulary prevents divergent per-slot languages and keeps Discussions/Issues consistent.
+- Good: GitHub constraint (only Copilot can be `requested_reviewers`) is encoded in validation rather than tribal knowledge.
+- Bad: two rails (dispatch + mechanism) mean there are two places a misconfiguration can happen. Mitigation: validation, and the mechanism table lives in-repo so it's versioned with the router.
+- Bad: `pr-triage` being non-overridable is a design opinion. If a user ever wants another orchestrator bot to take over, they'd fork this ADR — that's the right bar for that decision.
+- Neutral: when GitHub loosens the `requested_reviewers` whitelist (unlikely soon), the mechanism table gets new rows; nothing else changes.
+
+## Pros and Cons of the Options
+
+### Option A: one theme key
+- Good: simplest possible config. Great when the agency is homogeneous.
+- Bad: no expressive way to mix — "Copilot for PR reviews, Claude for everything else" forces you out of the schema.
+
+### Option B: flat per-function map
+- Good: explicit; no implicit inheritance.
+- Bad: verbose. Swapping the whole agency means rewriting N slots.
+- Bad: no obvious place to say "everything not listed goes here."
+
+### Option C: cascade (chosen)
+- Good: combines A's brevity for homogeneous cases with B's expressiveness for mixed ones.
+- Good: mirrors how design tokens and CSS custom properties work — familiar mental model.
+- Bad: users have to know the default-plus-override pattern. Mitigated by the config being small (7 slots).
+
+## More Information
+
+- [ADR 0003](0003-bot-identity-separation.md) — identity separation; mechanism-rail handler names map to these logins.
+- [ADR 0005](0005-copilot-reviewer-loop.md) — the `pr-reviews[copilot]` loop contract (terminal-state invariant, triage taxonomy, non-convergence rule).
+- [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill — authoritative definition of the `pr-reviews[copilot]` mechanism.
+- [ADR 0002](0002-use-feature-dev-main-branch-model.md) — branch model; clarifies that human approval is the merge gate regardless of routing.

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -70,7 +70,7 @@ orchestrator:
 
 `pr-reviews` is the one slot the cascade does *not* apply to by default. The `default:` key covers `bug-reports`, `issues`, `discussions`, `documentation`, and `pr-prep`; `pr-reviews` gets a schema-provided default of `[copilot]` and is only changed via an explicit `orchestrator.slots.pr-reviews` override. `pr-triage` is not a slot at all (see below).
 
-### The seven functions (slots)
+### The six slots (and one inherent function)
 
 | Slot | What it covers | Default handler mechanism |
 |---|---|---|
@@ -111,11 +111,11 @@ orchestrator:
 
 | Handler name | Mechanism | Valid slots |
 |---|---|---|
-| `claude` | `@mention` of `@claude` + Claude Code Action workflow | all except `pr-reviews[reviewer]` |
-| `claude-preflight` | Skill run during `pr-prep` (no `@mention`) | `pr-reviews` only (as preflight) |
+| `claude` | `@mention` of `@claude` + Claude Code Action workflow | any slot; in `pr-reviews`, only as a preflight entry (cannot be assigned via `requested_reviewers`) |
+| `claude-preflight` | Skill run during `pr-prep` (no `@mention`) | `pr-reviews` only, as a preflight entry |
 | `copilot` | `requested_reviewers` + `pull_request_review` webhook loop | `pr-reviews` only (GitHub constraint) |
 | `maintainer` | Ping `@thomHayner` | all |
-| *(future)* `codex` | `@codex` mention or dedicated action | all except `pr-reviews[reviewer]` until GitHub whitelists |
+| *(future)* `codex` | `@codex` mention or dedicated action | any slot; in `pr-reviews`, only as a preflight entry until GitHub whitelists it for `requested_reviewers` |
 
 Constraint enforcement: `scaleforce[bot]` rejects config that puts a non-assignable handler into `pr-reviews` as a reviewer entry (would silently no-op at runtime otherwise). Preflight entries are fine regardless of App whitelisting since they don't touch `requested_reviewers`.
 

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -111,6 +111,8 @@ pr-reviews:
 
 Constraint enforcement: `scaleforce[bot]` rejects config that puts a non-assignable handler into `pr-reviews` as a reviewer entry (would silently no-op at runtime otherwise). Preflight entries are fine regardless of App whitelisting since they don't touch `requested_reviewers`.
 
+**Actor provenance**: every handler runs its mechanism under the handler's own installation / app token — Claude writes post as `claude[bot]`, Copilot's reviewer output is `copilot-pull-request-reviewer[bot]`, dispatcher/orchestration writes are `scaleforce[bot]`. The dispatcher never proxies a handler's output under the maintainer PAT. See [ADR 0003 § Actor provenance invariant](0003-bot-identity-separation.md#actor-provenance-invariant).
+
 ### Shared vocabulary across slots
 
 All slots that produce structured output (issues triage, PR reviews, discussions) use the same six-outcome taxonomy from [ADR 0005](0005-copilot-reviewer-loop.md):

--- a/docs/adr/0007-github-function-routing.md
+++ b/docs/adr/0007-github-function-routing.md
@@ -61,8 +61,14 @@ Terse form for "whole agency" configs:
 
 ```yaml
 orchestrator:
-  default: claude   # everything Claude-owned; pr-reviews still uses Copilot via the constraint below
+  default: claude
+  # pr-reviews is not inherited from default. It has a built-in default of
+  # [copilot] because Copilot is the only AI that can be assigned via
+  # requested_reviewers (see "Mechanism rail" below). Override explicitly
+  # under orchestrator.slots.pr-reviews to extend or replace the list.
 ```
+
+`pr-reviews` is the one slot the cascade does *not* apply to by default. The `default:` key covers `bug-reports`, `issues`, `discussions`, `documentation`, and `pr-prep`; `pr-reviews` gets a schema-provided default of `[copilot]` and is only changed via an explicit `orchestrator.slots.pr-reviews` override. `pr-triage` is not a slot at all (see below).
 
 ### The seven functions (slots)
 
@@ -92,9 +98,11 @@ Because:
 Schema allows:
 
 ```yaml
-pr-reviews:
-  - copilot                 # GitHub-reviewer mechanism; the recursive loop from ADR 0005
-  - claude-preflight        # skill mechanism; runs in pr-prep before PR opens
+orchestrator:
+  slots:
+    pr-reviews:
+      - copilot              # GitHub-reviewer mechanism; the recursive loop from ADR 0005
+      - claude-preflight     # skill mechanism; runs in pr-prep before PR opens
 ```
 
 `scaleforce[bot]` consults the list and dispatches each entry through its declared mechanism. The `copilot` entry triggers the loop described in [ADR 0005](0005-copilot-reviewer-loop.md).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,3 +19,6 @@ See [`template.md`](template.md) — copy it for new ADRs.
 - [0002](0002-use-feature-dev-main-branch-model.md) — Use `feature → dev → main` branch model
 - [0003](0003-bot-identity-separation.md) — Separate bot identities for orchestration vs. AI work
 - [0004](0004-docs-tree-over-github-wiki.md) — Use `docs/` tree instead of GitHub Wiki
+- [0005](0005-copilot-reviewer-loop.md) — Copilot-reviewer loop: terminal-state invariant, triage taxonomy, anchor on `copilot-recursive-review` skill
+- [0006](0006-llm-observability.md) — LLM observability: structured agent-event logs now, tracing vendor deferred
+- [0007](0007-github-function-routing.md) — GitHub function routing: cascading defaults with per-function overrides

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,7 +4,7 @@ Decisions that shape the system, captured in [MADR](https://adr.github.io/madr/)
 
 ## Conventions
 
-- One file per decision: `NNNN-short-slug.md`, sequentially numbered.
+- One file per decision: `NNNN-short-slug.md`. Numbers are assigned in order of proposal; a reserved number for an in-flight ADR may briefly leave a gap in the merged index until that ADR lands. Do not renumber a merged ADR to close a gap — inbound links depend on the number being stable.
 - Status flows: `proposed` → `accepted` → (optionally) `deprecated` / `superseded by NNNN`.
 - Never delete an ADR. Supersede it with a new one and update the old one's status.
 - Architecture-affecting PRs must add or update an ADR in the same PR.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,5 +20,4 @@ See [`template.md`](template.md) — copy it for new ADRs.
 - [0003](0003-bot-identity-separation.md) — Separate bot identities for orchestration vs. AI work
 - [0004](0004-docs-tree-over-github-wiki.md) — Use `docs/` tree instead of GitHub Wiki
 - [0005](0005-copilot-reviewer-loop.md) — Copilot-reviewer loop: terminal-state invariant, triage taxonomy, anchor on `copilot-recursive-review` skill
-- [0006](0006-llm-observability.md) — LLM observability: structured agent-event logs now, tracing vendor deferred
 - [0007](0007-github-function-routing.md) — GitHub function routing: cascading defaults with per-function overrides

--- a/docs/setup/bot-identity.md
+++ b/docs/setup/bot-identity.md
@@ -8,7 +8,8 @@
 |---|---|---|
 | `scaleforce[bot]` | Orchestration: triage, routing, PR mediation | This repo's Probot. Configure at https://github.com/settings/apps/scaleforce |
 | `claude[bot]` | Substantive AI: code, deep PR review | Install [Claude GitHub App](https://github.com/apps/claude) |
-| `copilot-swe-agent[bot]` | Parallel coding agent | Enable Copilot coding agent in repo settings |
+| `copilot-pull-request-reviewer[bot]` | GitHub Copilot PR reviewer (active). `scaleforce[bot]` re-requests reviews from this identity until clean. | Assign Copilot as a reviewer on a PR; requires a Copilot subscription. |
+| `copilot-swe-agent[bot]` | Copilot coding agent (documented, not the primary workflow) | Enable Copilot coding agent in repo settings |
 
 ## The maintainer's git config — never let agents change
 

--- a/llm-wiki/agents/copilot.md
+++ b/llm-wiki/agents/copilot.md
@@ -23,9 +23,9 @@ The loop is defined authoritatively by the [`copilot-recursive-review`](https://
 ### Loop summary
 
 1. `scaleforce[bot]` requests review from Copilot and records the current HEAD SHA.
-2. Waits on a cache-warm cadence (~270s default).
-3. On each wake, fetches Copilot reviews matching HEAD. The `pull_request_review` webhook does **not** carry an inline-comment count — compute it with `GET /repos/{o}/{r}/pulls/{n}/reviews/{review_id}/comments` and filter to the current HEAD.
-4. Each inline comment is triaged into one of six terminal states:
+2. Waits on a configurable polling cadence (skill default: 270s, tuned to its own runtime; ScaleForce picks its own).
+3. On each wake, fetches Copilot reviews matching HEAD. The `pull_request_review` webhook does **not** carry inline-comment counts or thread-resolution state — compute both with `GET /repos/{o}/{r}/pulls/{n}/reviews/{review_id}/comments` plus the GraphQL `pullRequest.reviewThreads` field, filtered to the current HEAD.
+4. Each review thread (which may contain multiple inline comments) is triaged into one of six terminal states — triage and resolution are both thread-level:
 
 | Triage | Reply | Side effect | Thread |
 |---|---|---|---|

--- a/llm-wiki/agents/copilot.md
+++ b/llm-wiki/agents/copilot.md
@@ -13,25 +13,41 @@ Both are GitHub products, so comments from either get the purple **AI** pill (th
 
 ## Reviewer role — the active use case
 
-- **Invoke**: assign Copilot as a reviewer on a PR (via the Reviewers sidebar, or programmatically via `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["Copilot"]`).
-- **Event to listen for**: `pull_request_review` with `review.user.login === "copilot-pull-request-reviewer[bot]"`.
-- **Copilot cannot approve.** GitHub/Microsoft restricts `copilot-pull-request-reviewer[bot]` to `COMMENTED` reviews — it will never post an `APPROVED` state. So the loop-exit condition must be "zero comments," not "approved."
-- **Copilot only reviews — it does not fix.** Its output is suggestions. The PR author is responsible for triaging those suggestions and deciding how to proceed (accept, modify, or reject with rationale).
-- **Re-request loop** (driven by `scaleforce[bot]`):
-  1. Request review from Copilot.
-  2. When Copilot's review arrives:
-     - **Zero review comments** → **exit** (this is "clean").
-     - **One or more review comments** → route to the **PR author** (loops 1–6) or **escalate to the maintainer** (loop 7) to triage, fix, push, then re-request review.
-  3. Recurse until a review comes back with zero comments or the 7-iteration cap fires.
-- **Max 7 iterations.** `scaleforce[bot]` tracks iteration count per PR. On the 7th review-with-comments, the routing flips from PR author to maintainer — author/Copilot aren't converging and a human needs to break the tie.
-- **Routing by PR author** (who `scaleforce[bot]` pings to handle the comments):
-  | PR author | Routes to |
-  |---|---|
-  | `claude[bot]` | `@claude` in the PR thread |
-  | `thomHayner` (maintainer) | the maintainer |
-  | future code agents (e.g. Codex) | that agent's handle |
+The loop is defined authoritatively by the [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill (path: `skills/software-development/copilot-recursive-review/SKILL.md`). [ADR 0005](../../docs/adr/0005-copilot-reviewer-loop.md) captures the decision to anchor `scaleforce[bot]` on it. This file is the agent-facing summary; the skill is the source of truth.
 
-  The PR author agent owns triage: weigh Copilot's suggestions, apply fixes where warranted, reply inline with rationale where rejecting, then push and ask `scaleforce[bot]` to re-request review.
+- **Invoke**: assign Copilot as a reviewer on a PR. UI shows the display name **Copilot** in the Reviewers sidebar; the underlying login is `copilot-pull-request-reviewer[bot]`. Programmatic: `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["copilot-pull-request-reviewer[bot]"]` (send the login, not the display name).
+- **Event to listen for**: `pull_request_review` with `review.user.login === "copilot-pull-request-reviewer[bot]"`.
+- **Copilot cannot approve.** GitHub/Microsoft restricts `copilot-pull-request-reviewer[bot]` to `COMMENTED` reviews — it will never post an `APPROVED` state. Branch-protection approvals still require a human reviewer.
+- **Copilot only reviews — it does not fix.** Its output is suggestions. `scaleforce[bot]` (via the skill) triages each thread.
+
+### Loop summary
+
+1. `scaleforce[bot]` requests review from Copilot and records the current HEAD SHA.
+2. Waits on a cache-warm cadence (~270s default).
+3. On each wake, fetches Copilot reviews matching HEAD. The `pull_request_review` webhook does **not** carry an inline-comment count — compute it with `GET /repos/{o}/{r}/pulls/{n}/reviews/{review_id}/comments` and filter to the current HEAD.
+4. Each inline comment is triaged into one of six terminal states:
+
+| Triage | Reply | Side effect | Thread |
+|---|---|---|---|
+| **FIX** | "Applied in `<sha>`: …" | commit pushed | resolved |
+| **REJECT** | "Not changing: …" | none | resolved |
+| **DISCUSS** | "Opened <Discussion link>." | new Discussion | resolved |
+| **DEFER** | "Filed <Issue link>." | new Issue | resolved |
+| **NOISE** | "Skipping — <why>." | none | resolved |
+| **HUMAN-PAUSE** | "Pausing — <reason>." | surface to user; loop halts | left open |
+
+5. Re-request review on the new HEAD. Repeat.
+
+### Termination (any one triggers exit)
+
+- Zero unresolved Copilot threads on the current HEAD after a fresh review.
+- `HUMAN-PAUSE` raised this round.
+- Maintainer says stop / takes over.
+- **Same class of comment recurs for 3 rounds with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve (replaces the earlier 7-iteration hard cap; pattern detection beats counter-based).
+
+### Other bots on the same PR
+
+Vercel previews, CodeRabbit, Sentry, Renovate, in-house agentic bots — the same six-outcome triage applies. `FIX` takes four shapes for bot threads: fix-on-our-end, agent-to-agent directive (e.g. `@coderabbitai resolve`), trigger-external-action (rerun workflow, redeploy), or acknowledge-and-resolve. The loop is done only when **all** bot threads are terminal, not just Copilot's. Detail lives in the skill's "Other bots on the same PR" section.
 
 ## Coding-agent role — documented, not active
 

--- a/llm-wiki/agents/copilot.md
+++ b/llm-wiki/agents/copilot.md
@@ -1,24 +1,44 @@
-# copilot-swe-agent[bot]
+# GitHub Copilot
 
-GitHub's parallel coding agent.
+GitHub Copilot surfaces in this repo under two distinct bot logins, depending on the role it's playing. Treating them as separate identities matters because `scaleforce[bot]` routes events differently for each.
 
-## Identity
+## Identities
 
-- Bot username: `copilot-swe-agent[bot]` (when the coding agent acts)
-- Source: GitHub Copilot, configured in repo settings
-- Distinct from inline Copilot suggestions in the editor — the SWE agent opens PRs
+| Login | Role | Status in this repo |
+|---|---|---|
+| `copilot-pull-request-reviewer[bot]` | PR reviewer | **Active.** Requires a Copilot subscription. Assigned as a reviewer on PRs; posts reviews and review comments. |
+| `copilot-swe-agent[bot]` | Coding agent (opens PRs) | Documented, not the primary workflow. Would produce a parallel implementation alongside Claude. |
 
-## How to invoke
+Both are GitHub products, so comments from either get the purple **AI** pill (third-party Apps like `claude[bot]` and `scaleforce[bot]` only get the gray **bot** pill — GitHub UI policy).
 
-- Assign an issue to Copilot
-- Use the "Code with Copilot" UI in PR view
-- (Future) `@copilot` mentions if/when supported
+## Reviewer role — the active use case
 
-## Role in this stack
+- **Invoke**: assign Copilot as a reviewer on a PR (via the Reviewers sidebar, or programmatically via `POST /repos/{owner}/{repo}/pulls/{number}/requested_reviewers` with `reviewers: ["Copilot"]`).
+- **Event to listen for**: `pull_request_review` with `review.user.login === "copilot-pull-request-reviewer[bot]"`.
+- **Copilot cannot approve.** GitHub/Microsoft restricts `copilot-pull-request-reviewer[bot]` to `COMMENTED` reviews — it will never post an `APPROVED` state. So the loop-exit condition must be "zero comments," not "approved."
+- **Copilot only reviews — it does not fix.** Its output is suggestions. The PR author is responsible for triaging those suggestions and deciding how to proceed (accept, modify, or reject with rationale).
+- **Re-request loop** (driven by `scaleforce[bot]`):
+  1. Request review from Copilot.
+  2. When Copilot's review arrives:
+     - **Zero review comments** → **exit** (this is "clean").
+     - **One or more review comments** → route to the **PR author** (loops 1–6) or **escalate to the maintainer** (loop 7) to triage, fix, push, then re-request review.
+  3. Recurse until a review comes back with zero comments or the 7-iteration cap fires.
+- **Max 7 iterations.** `scaleforce[bot]` tracks iteration count per PR. On the 7th review-with-comments, the routing flips from PR author to maintainer — author/Copilot aren't converging and a human needs to break the tie.
+- **Routing by PR author** (who `scaleforce[bot]` pings to handle the comments):
+  | PR author | Routes to |
+  |---|---|
+  | `claude[bot]` | `@claude` in the PR thread |
+  | `thomHayner` (maintainer) | the maintainer |
+  | future code agents (e.g. Codex) | that agent's handle |
 
-Often produces a parallel implementation alongside Claude's, especially when the task is well-scoped. The maintainer (or `scaleforce[bot]` mediation) compares outputs and chooses or merges.
+  The PR author agent owns triage: weigh Copilot's suggestions, apply fixes where warranted, reply inline with rationale where rejecting, then push and ask `scaleforce[bot]` to re-request review.
 
-## Notes
+## Coding-agent role — documented, not active
 
-- Copilot's coding agent is the only third-party identity that GitHub gives the purple **AI** pill — because it's a GitHub product. Claude and ScaleForce get the gray **bot** pill.
-- Copilot follows `.github/copilot-instructions.md` if present (create when needed).
+- **Invoke**: assign an issue to Copilot, or use "Code with Copilot" in the PR view.
+- **Event**: PRs opened by `copilot-swe-agent[bot]`.
+- Not the primary workflow here. If enabled, it would run alongside Claude and the maintainer (or `scaleforce[bot]`) would compare outputs.
+
+## Config
+
+- `.github/copilot-instructions.md` applies to both roles when present (create when needed).

--- a/llm-wiki/agents/copilot.md
+++ b/llm-wiki/agents/copilot.md
@@ -43,7 +43,7 @@ The loop is defined authoritatively by the [`copilot-recursive-review`](https://
 - Zero unresolved Copilot threads on the current HEAD after a fresh review.
 - `HUMAN-PAUSE` raised this round.
 - Maintainer says stop / takes over.
-- **Same class of comment recurs for 3 rounds with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve (replaces the earlier 7-iteration hard cap; pattern detection beats counter-based).
+- **Same class of thread recurs for 3 rounds with no progress** → surface as `HUMAN-PAUSE` and stop. This is the non-convergence safety valve (replaces the earlier 7-iteration hard cap; pattern detection beats counter-based).
 
 ### Other bots on the same PR
 

--- a/llm-wiki/glossary.md
+++ b/llm-wiki/glossary.md
@@ -6,8 +6,9 @@
 | **ScaleForceAgency** | The GitHub organization that owns the apps and (eventually) the repos. |
 | **The maintainer** | The human in the loop. `thomHayner` on GitHub. |
 | **Orchestration bot** | `scaleforce[bot]` — this repo's Probot. Triages, routes, mediates threads. Does not write code. |
-| **AI dev** | An agent that writes code: `claude[bot]`, `copilot-swe-agent[bot]`. |
-| **Agent** | Any non-human actor: orchestration bot, AI devs, infra bots (Dependabot, Vercel). |
+| **AI dev** | An agent that writes code: `claude[bot]`, `copilot-swe-agent[bot]` (documented, not active). |
+| **AI reviewer** | `copilot-pull-request-reviewer[bot]` — GitHub Copilot when assigned as a PR reviewer. `scaleforce[bot]` re-requests reviews until clean. |
+| **Agent** | Any non-human actor: orchestration bot, AI devs, AI reviewers, infra bots (Dependabot, Vercel). |
 | **MADR** | Markdown Any Decision Records — the ADR format used in [`docs/adr/`](../docs/adr/). |
 | **PRD** | Product Requirements Document. Lives in [`docs/prd/`](../docs/prd/). |
 | **Spec** | Technical specification. Lives in [`docs/specs/`](../docs/specs/). |


### PR DESCRIPTION
## Summary

Three-part docs PR for `scaleforce[bot]` orchestration:

1. **Identity docs** — distinguish `copilot-pull-request-reviewer[bot]` (active PR reviewer) from `copilot-swe-agent[bot]` (documented, not primary). Updates across CLAUDE.md, AGENTS.md, `.github/README.md`, `docs/setup/bot-identity.md`, ADR 0003, and `llm-wiki/`.
2. **ADR 0005 rewritten** — original "zero-comments / 7-iteration cap / PR-author triage" model replaced by the richer contract from the working [`copilot-recursive-review`](https://github.com/thomHayner/ai-skill-builder-library) skill: six-outcome terminal-state invariant (FIX / REJECT / DISCUSS / DEFER / NOISE / HUMAN-PAUSE) and pattern-based non-convergence detection (same class of comment for 3 rounds = HUMAN-PAUSE). Covers non-Copilot bot traffic (Vercel, CodeRabbit, Sentry, Renovate) with the same taxonomy.
3. **ADR 0007 added** — cascading routing schema with per-function overrides. Default handler + per-slot overrides for `bug-reports`, `issues`, `discussions`, `documentation`, `pr-prep`, `pr-reviews` (a multi-handler list since only Copilot can be assigned via `requested_reviewers`). `pr-triage` is intentionally not a slot — it's `scaleforce[bot]`'s inherent work. Shared FIX/REJECT/DISCUSS/DEFER/NOISE/HUMAN-PAUSE vocabulary across all slots.

## Related

- New: [`docs/adr/0005-copilot-reviewer-loop.md`](docs/adr/0005-copilot-reviewer-loop.md) (rewritten)
- New: [`docs/adr/0007-github-function-routing.md`](docs/adr/0007-github-function-routing.md)
- Updated: [`docs/adr/0003-bot-identity-separation.md`](docs/adr/0003-bot-identity-separation.md), [`llm-wiki/agents/copilot.md`](llm-wiki/agents/copilot.md)

## Note: prior Copilot review superseded

Copilot reviewed an earlier HEAD (commit `24a3593`) and left 6 inline comments targeting the original ADR 0005 / copilot.md content. The rewrite at `1142fb3` replaces that content, so comments #2 (how to compute zero-comments), #3 (7-iter cap wording), #5 (same as #2), and #6 (same as #3) are obsolete. Comment #1 (Probot capitalization) and #4 (display-name vs login mapping) have been addressed in the rewrite.

Re-requesting review after push will surface a fresh pass on the current content.

## Test plan

Docs-only. No code paths touched.

- [x] ADR cross-links verified (0005 ↔ 0003 ↔ 0007 ↔ `llm-wiki/agents/copilot.md` ↔ skill link).
- [x] `docs/adr/README.md` index updated.
- [x] Copilot reviewer login verified empirically.
- [x] Non-assignable reviewers (`claude[bot]`, `scaleforce[bot]`) verified to be silently rejected by `requested_reviewers` — encoded in ADR 0007's mechanism rail.
- [ ] Re-request Copilot review on the new HEAD to confirm the rewrite holds up.

## Checklist

- [x] One logical change per PR (expanded: identity docs + ADR 0005 rewrite + ADR 0007; all interlocking)
- [x] CLAUDE.md / AGENTS.md respected
- [x] Architecture-affecting: ADR 0005 rewritten, ADR 0007 added
- [x] No new dependencies
- [x] `llm-wiki/` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)