### PR TITLE
Flag RNRO as moderation-strategy research in ADR 0009

### DIFF
--- a/docs/CHARTER.md
+++ b/docs/CHARTER.md
@@ -1,0 +1,115 @@
+# scaleforce[bot] — Scope Charter
+
+- **Status**: draft
+- **Date**: 2026-04-22
+- **Maintainer**: @thomHayner
+- **Companion ADRs**: [0003](adr/0003-bot-identity-separation.md), [0005](adr/0005-copilot-reviewer-loop.md), [0007](adr/0007-github-function-routing.md), [0008](adr/0008-engineering-branch-scaleforce-instrument.md), [0009](adr/0009-ordered-cross-repo-deliberation.md)
+
+The minimal high-level statement of what scaleforce[bot] is, what it is not, and which neighbors it defers to for which functions. ADRs encode the individual decisions that back this charter. Read this first; drop into an ADR when a specific decision needs stress-testing.
+
+## Position in the tree
+
+**scaleforce[bot] is the GitHub instrument of the Engineering branch.** It is not a branch. See [ADR 0008](adr/0008-engineering-branch-scaleforce-instrument.md) for the decision and its drivers.
+
+The agency tree has branches that *reason* — honey-claw (executive), honeycrisp (Chief-of-Staff router), and domain branches including PersonalOS (time), Agency (people), and Engineering (codebase). Each branch is an LLM-wiki that owns its domain and stays inside the 6–10 sub-concern fan-out budget. Engineering is the engineering branch; its sub-concerns include per-repo wiki-agents, the release process, architectural themes, and third-party integrations.
+
+scaleforce is to Engineering what a Gmail MCP is to PersonalOS or a CRM MCP is to Agency: the instrument through which the branch operates its external surface. The external surface, in Engineering's case, is GitHub — so scaleforce's domain is GitHub, end-to-end.
+
+One caveat: scaleforce is more active than a typical MCP. It runs bounded autonomous loops on webhooks (review loops, scheduled sweeps), maintains state on PRs between events, and calls back to Engineering at decision points rather than being re-invoked step-by-step. It is a **long-running deterministic instrument** — a daemon tool, not a request/response one.
+
+## Thesis
+
+**scaleforce is the deterministic fast-path for GitHub.** It replaces LLM-latency with Probot-latency for anything on GitHub that has a stable, nameable route or a rule-based answer. Agents are slow, non-deterministic, expensive; scaleforce is fast, deterministic, cheap. The branch wins by *never* invoking an LLM when a lookup, a webhook dispatch, a permission check, a rule, or a config-driven route will do.
+
+Narrow templated LLM calls are allowed inside scaleforce for **classification from free text** (e.g., extracting multi-repo scope from prose when labels are absent, or parsing a Copilot thread into a six-outcome bucket). These calls must be structured, bounded, cacheable, and have deterministic fallbacks. They are not reasoning; they are reading comprehension wrapped in a schema. See [ADR 0005 § Classifier boundary](adr/0005-copilot-reviewer-loop.md#classifier-boundary) for where such calls are permitted.
+
+The dividing line, whenever a boundary is unclear:
+
+- **"Can this decision be made by a rule, a count, a lookup, or a configured tie-breaker?"** → scaleforce does it with Probot tools.
+- **"Does this decision require reading comprehension on free text to produce a structured classification?"** → narrow templated LLM call inside scaleforce is permitted.
+- **"Does this decision require codebase knowledge or reasoning about the user's engineering?"** → hand to Engineering.
+
+## What scaleforce does
+
+Primary responsibilities, all deterministic except where flagged:
+
+1. **Review loop orchestration** ([ADR 0005](adr/0005-copilot-reviewer-loop.md)). Request reviews from Copilot, poll for review arrival, triage threads into the six-outcome taxonomy (triage-to-bucket classification is the allowed narrow-LLM case), apply FIXes via handlers, open Discussions for DISCUSS and Issues for DEFER, reply on and resolve threads, re-request review on new HEAD, detect non-convergence.
+2. **Cross-repo deliberation machinery** ([ADR 0009](adr/0009-ordered-cross-repo-deliberation.md)). When Engineering identifies a question as multi-repo, scaleforce fans out to the named repo-wiki-agents, enforces ordered turn-taking (one agent at a time, within configured bounds per round), collects responses, posts structured round summaries, signals the moderator between rounds. Termination is convergence or pathology; there is no fixed round cap. Pathology is ADR 0005's "same class of thread recurring with no progress for 3 rounds." A hard backstop at ~25 rounds exists only for runaway protection in unattended loops — it is a tripwire, not a normal terminator.
+3. **Mechanical moderation.** Within cross-repo deliberation, scaleforce may moderate *mechanical* decisions — detecting unanimous agreement, applying a configured tie-breaker rule (e.g., "frontend wins on UX calls, backend wins on data-model calls"), consolidating duplicate concerns by keyword overlap, counting votes. Synthetic moderation — choosing between legitimate conflicting positions — is always Engineering's.
+4. **Scaffolding and convention enforcement.** Repo setup (labels, issue templates, PR templates, branch protections per [ADR 0002](adr/0002-use-feature-dev-main-branch-model.md)), ADR scaffolding (consistent MADR templates across repos), llm-wiki skeleton enforcement, drift detection against convention, and opening PRs against repos that have fallen out of convention. Templates live in the orchestrator repo and are propagated outward.
+5. **Notification-gap monitoring.** GitHub's notification surface covers PR review requests and Dependabot alerts reasonably but leaves gaps. scaleforce periodically sweeps: open issues across projects (not surfaced in notifications), Discussions without an `@mention` (also unsurfaced), stale PRs, unanswered review threads, and **GitHub Projects state — stalled items, iteration-health issues, orphaned drafts, and missing-field drift**. Projects is a fourth gap because its native notifications cover assignment only, not field changes, status moves, or iteration rollovers.
+6. **Routing implementation** ([ADR 0007](adr/0007-github-function-routing.md)). The dispatch table lives in `orchestrator.default` and `orchestrator.slots.*` config. scaleforce reads it and executes — it does not choose the routing.
+7. **Agent-event emission (the upward contract).** Every orchestration decision emits a structured event ([ADR 0006](adr/0006-llm-observability.md) schema). Once honeycrisp exists, these events are the contract by which upstream agents know what scaleforce is doing. Event types extend as new functions are added; the log is never scraped around.
+
+## What scaleforce does NOT do
+
+- **Does not author code.** Every authoring write is attributable to a handler (claude[bot], copilot-swe-agent[bot], future codex). scaleforce commits only scaffolding/templating output, and even then only as PRs, never as direct pushes.
+- **Does not reason about the codebase.** No architectural judgment, no feature-ownership calls, no "should we do X" decisions. Those are Engineering's.
+- **Does not synthesize across repos or across domains.** Fan-out yes; merge no. Side-by-side "frontend said X, backend said Y" is scaleforce; "the right answer is Z because..." is Engineering or honeycrisp.
+- **Does not choose routing policy.** Policy is config; scaleforce executes. Changing policy is a PR, reviewed by the maintainer.
+- **Does not cache wiki-agent answers** across events, paraphrase them, or override them. The repo-wiki-agent is authoritative for its repo.
+- **Does not call third-party APIs outside the GitHub surface.** Sentry, Vercel, Supabase etc. are consumed through their GitHub comments and check-runs. Their own APIs belong to other branches.
+- **Does not reach into non-GitHub task systems** (ClickUp, Linear outside its GitHub integration, etc.). GitHub Projects is in scope because it is GitHub-surface; non-GitHub task systems are another branch's instrument.
+- **Does not invoke an LLM when a lookup, a rule, or a config value answers the question.** Thesis violation.
+- **Does not accept runtime directives from sibling branches.** PersonalOS, Agency, and honeycrisp interact with scaleforce's domain *through the same GitHub surfaces a human uses* — open an issue, open a PR, comment on a thread. No side-channel APIs.
+- **Does not mutate its own routing config at runtime.** Declarative in-repo; changes go through PR.
+- **Does not make policy out of patterns.** If a classification pattern recurs, that's a config change Engineering proposes — scaleforce doesn't promote observed behavior to policy on its own.
+
+## Neighbors and handoffs
+
+| Neighbor | What they own that scaleforce must not do | What scaleforce owns that they must not do | Handoff mechanism |
+|---|---|---|---|
+| **Engineering (branch)** | Codebase reasoning, synthetic moderation, cross-repo decisions, architectural calls, novel classification | All GitHub-surface operations, loop state, notification sweeps, scaffolding | Engineering directs via config + in-thread directives; scaleforce reports via event log |
+| **honeycrisp (Chief of Staff)** | Cross-domain synthesis, priority filtering, upward summarization | GitHub-internal orchestration; all GitHub writes | Event log upward; no direct RPC; downward direction via GitHub surfaces only |
+| **honey-claw (executive)** | Prioritization across branches | GitHub execution | Via honeycrisp; never direct |
+| **PersonalOS** | Time, calendar, attention | Code state on GitHub | Disjoint; if correlation needed, honeycrisp mediates |
+| **Agency** | People, customers, CRM | Code state on GitHub | Disjoint; context (e.g., "priority customer") enters via GitHub labels/fields, not API |
+| **claude[bot]** | Code authoring, substantive review, spec/ADR drafting, answering `@claude` pings | Triage, routing, loop orchestration, identity enforcement | `@claude` mention in a thread scaleforce has prepared; scaleforce never authors on claude's behalf |
+| **copilot-pull-request-reviewer[bot]** | PR review output | Reviewer assignment, loop state, thread triage | `requested_reviewers` API; `pull_request_review` webhook |
+| **copilot-swe-agent[bot]** | Coding-agent PR authoring (when enabled) | Nothing scaleforce-specific | Issue assignment |
+| **per-repo wiki-LLM agents** | Repo-local knowledge and judgment | All GitHub-facing plumbing for that repo | Invoked by scaleforce during fan-out; their output is their own identity |
+| **Third-party agents** (Sentry, Vercel, Supabase, CodeRabbit, Renovate, etc.) | Their domain-specific analysis | GitHub-surface triage of their output | Via GitHub comments and check-runs only; scaleforce does not call their APIs |
+| **Non-GitHub task systems** (ClickUp, etc.) | Their own task/time/project management | Nothing GitHub-side | Out of scope; handled by another branch's instrument |
+| **Maintainer** | Approvals, merges, overrides, HUMAN-PAUSE resolutions | Everything else automatable | `HUMAN-PAUSE` surfaces; direct `@thomHayner` ping when necessary |
+
+## Actor provenance — two-layer attribution
+
+[ADR 0003](adr/0003-bot-identity-separation.md#actor-provenance-invariant)'s invariant holds: every GitHub write is attributable at the GitHub level to the identity that performed it — scaleforce[bot] for orchestration writes, claude[bot] for AI code work, the reviewer's identity for review output, the maintainer's identity only for explicit human decisions.
+
+At the tree level, a second layer applies (see [ADR 0003 § Tree-level attribution](adr/0003-bot-identity-separation.md#tree-level-attribution-upward-identity)): **the upward event log attributes reasoning to the reasoner.** If Engineering directed scaleforce to fan out across four repos, the GitHub post is scaleforce[bot]'s but the event log entry records Engineering as the decision-maker. honeycrisp's summaries of scaleforce activity are attributed to honeycrisp, not to scaleforce. The maintainer PAT is never a fallback at either layer.
+
+## Fan-out budgets
+
+- **Slot-level** (dispatch): the six [ADR 0007](adr/0007-github-function-routing.md) slots (bug-reports, issues, discussions, documentation, pr-prep, pr-reviews) plus inherent pr-triage. New slots require consolidation or a branch split, not expansion — the current count sits at the top of the budget.
+- **Cross-repo-level**: per deliberation, bounded by the tree's 6–10 rule. A question that genuinely touches more than ~10 repos is `HUMAN-PAUSE` on principle — no agent should decide that broadly in one pass.
+- **Handler-level**: no built-in cap, but mechanism rail validation ([ADR 0007](adr/0007-github-function-routing.md#mechanism-rail--what-each-handler-name-resolves-to)) ensures handlers only appear in slots where their mechanism works.
+
+## Termination rules (single taxonomy across loops)
+
+Any loop scaleforce runs terminates when **any** of these is true:
+
+- **Convergence** — the loop's success condition is met (zero unresolved threads, unanimous agreement, scaffolding applied, etc.).
+- **Maintainer intervention** — stop signal, takeover, or merge.
+- **Pathology** — [ADR 0005](adr/0005-copilot-reviewer-loop.md#termination)'s "same class recurring with no progress for 3 rounds." Surfaced as `HUMAN-PAUSE`.
+- **Hard backstop** — ~25 rounds, purely runaway protection for unattended loops. Should almost never fire.
+
+There is no fixed productive-round cap. Seven-round converging loops are successes.
+
+## Drift tripwires
+
+Observable behaviors that mean scaleforce is wandering out of scope:
+
+- An LLM is invoked where a lookup, a rule, or a config value would answer. → thesis violation.
+- A slot appears in the config that isn't a GitHub function. → scope creep.
+- A non-GitHub webhook or inbound API call from a sibling branch. → side-channel; upward contract has inverted.
+- A commit shows scaleforce[bot] in any author field, even as co-author. → authoring code.
+- An event appears in the log that's shaped like synthesis ("here's what's happening across your repos") rather than fact-shaped ("X happened in repo Y at time T"). → trying to be honeycrisp.
+- A wiki-agent's answer is cached across events, or paraphrased in a later response. → becoming a wiki.
+- A policy decision appears in the event log without a corresponding config change. → making policy from pattern.
+- A cross-repo moderation output merges positions ("the right call is Z") rather than assembling them side-by-side. → synthetic moderation where scaleforce should have deferred to Engineering.
+- A third-party-agent's own API gets called directly. → leaking into another branch.
+- A non-GitHub task system appears in an event, config, or write path. → reaching past the GitHub surface.
+
+## Tripwire review cadence
+
+Each tripwire gets an event type in [ADR 0006](adr/0006-llm-observability.md)'s schema. A scheduled sweep counts occurrences and flags upward via honeycrisp if any tripwire fires unexpectedly. The charter isn't real unless violations are observable.

--- a/docs/adr/0003-bot-identity-separation.md
+++ b/docs/adr/0003-bot-identity-separation.md
@@ -55,6 +55,31 @@ The identity table above is not descriptive — it is an **operational invariant
 
 **How to enforce.** Before merging code that performs a GitHub write, ask: *which identity does this post under at runtime?* If the answer is "whoever ran the script," the code is wrong. `scaleforce[bot]` writes use the Probot / Octokit client built from its installation token; Claude writes use the Claude App's token; the maintainer PAT is not a fallback.
 
+### Tree-level attribution (upward identity)
+
+*Added 2026-04-22 alongside [ADR 0008](0008-engineering-branch-scaleforce-instrument.md).*
+
+The identity table above is a **GitHub-level** invariant: every GitHub write is attributable to the GitHub App / account that performed it. Once the agency tree has an Engineering branch directing `scaleforce[bot]` and a honeycrisp router consuming its events ([ADR 0008](0008-engineering-branch-scaleforce-instrument.md)), a second layer applies:
+
+**The upward event log attributes reasoning to the reasoner, not to the instrument that executed.**
+
+Concretely:
+
+- When Engineering directs `scaleforce[bot]` to fan out across four repos, the GitHub post is `scaleforce[bot]`'s (GitHub layer) but the [ADR 0006](0006-llm-observability.md) event-log entry records Engineering as the `decided_by` (tree layer). Both attributions are required; neither stands alone.
+- When `scaleforce[bot]` makes a decision within its own deterministic scope (apply a routing-table lookup, enforce a turn-taking bound, emit a notification-gap sweep result), `decided_by` is `scaleforce` and `decided_under` is `engineering` (its branch).
+- When a narrow templated LLM call inside `scaleforce[bot]` classifies free text (see [ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary)), `decided_by` is still `scaleforce` but `classifier` names the specific classifier template that was invoked, so the reasoning path is traceable.
+- `honeycrisp`'s summaries of `scaleforce[bot]` activity are attributed to `honeycrisp`, not paraphrased as if they came from `scaleforce`. When honeycrisp posts summary output on GitHub (rare; usually via Engineering), the GitHub-layer write is still whoever holds the installation token for that write — the attribution layers don't collapse into each other.
+- The maintainer PAT is never a fallback at either layer. An event logged as `decided_by: maintainer` corresponds to an explicit human decision, not to "the script happened to be running under a PAT."
+
+**Event-schema implication.** [ADR 0006](0006-llm-observability.md)'s `scaleforce.event.v1` schema already carries `actor` (GitHub-layer). Add two tree-layer fields:
+
+- `decided_by` — the tree-level identity whose reasoning produced this action. Values: `engineering`, `honeycrisp`, `honey-claw`, `scaleforce` (for decisions inside its own deterministic scope), `maintainer`.
+- `decided_under` — the branch whose instrument or sub-concern executed. Usually `engineering` for scaleforce events; clarifies which branch "owns" the action for cross-branch audits.
+
+Existing consumers of the v1 schema can ignore these fields until they matter; the addition is backward-compatible.
+
+**Why it matters.** Without upward attribution, a honeycrisp that consumes the event log can't tell whether a decision was Engineering's, scaleforce's, or a fallback. That collapses the same audit-trail invariant at the tree level that the GitHub-layer invariant protects at the GitHub level. The whole point of having reasoning in one place and execution in another is to keep the two separately inspectable.
+
 ### Consequences
 
 - Good: every thread shows who said what, instantly.

--- a/docs/adr/0005-copilot-reviewer-loop.md
+++ b/docs/adr/0005-copilot-reviewer-loop.md
@@ -90,6 +90,38 @@ Probot is stateless across events. The loop's state — round number, HEAD SHA, 
 
 Critically: "zero unresolved threads on this HEAD" is not inferable from the `pull_request_review` webhook payload — that event carries neither inline-comment counts nor thread resolution state. `scaleforce[bot]` must compute it by fetching the review's inline comments (`GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments`) plus the PR's review threads via the GraphQL `pullRequest.reviewThreads` field (for `isResolved`), then filtering to threads tied to the current HEAD SHA.
 
+### Classifier boundary
+
+*Added 2026-04-22 alongside [ADR 0008](0008-engineering-branch-scaleforce-instrument.md).*
+
+Triaging a Copilot thread into FIX / REJECT / DISCUSS / DEFER / NOISE / HUMAN-PAUSE requires reading comprehension on free text — the thread is prose, not a labeled payload. This is the **one place** inside `scaleforce[bot]`'s loop where a narrow templated LLM call is permitted. [ADR 0008](0008-engineering-branch-scaleforce-instrument.md) establishes that scaleforce is Engineering's instrument and that reasoning belongs to Engineering; this section names the exception.
+
+**What is permitted inside scaleforce:**
+
+- **Structured classification of free text into a fixed taxonomy.** Triage (one of six outcomes), scope detection ("does this thread mention a file outside this repo?"), intent extraction from `@scaleforce` directives, thread-class identification for non-convergence detection. Inputs are bounded (one thread at a time; a configurable prose-length cap), outputs are structured (an enum + a short rationale), and the model has no authority to take actions — it returns a label, scaleforce decides what to do with it.
+- **Summarization of a thread to assemble a context packet for a handler.** Compressing a Copilot thread (possibly with its inline-comment siblings) into a single paragraph that a handler like `claude[bot]` receives alongside the original payload. Summarization is a classification-adjacent task: it does not invent content, does not decide, and its output is auditable against the source.
+- **Non-convergence pattern detection.** Recognizing "the thread Copilot just raised is the same *class* as the one we FIXed two rounds ago" is a classification over two pieces of text. Permitted inside scaleforce; the decision to surface `HUMAN-PAUSE` flows from the classification plus the round count (which is a deterministic state field).
+
+**What is not permitted inside scaleforce — even if an LLM call would answer:**
+
+- Deciding *what* a FIX should be. scaleforce classifies a thread as FIX-worthy; the handler (claude[bot], a repo-wiki-agent, etc.) decides and applies the change.
+- Judging whether a REJECT is correct for this codebase. scaleforce can classify "this comment looks like a taste disagreement" (triage), but "we should reject because our convention says X" requires codebase knowledge and belongs to Engineering or the repo-wiki-agent.
+- Synthesizing across multiple threads or across repos. Fan-out yes; merge no. See [ADR 0009](0009-ordered-cross-repo-deliberation.md).
+- Choosing between legitimate conflicting positions. That is synthetic moderation and it is Engineering's.
+- Answering novel or ambiguous classifications where the classifier's confidence is low. In that case scaleforce escalates to Engineering (or the relevant repo-wiki-agent) rather than guessing — the output of the templated call includes a confidence field, and below a configured threshold the call returns `NEEDS_ENGINEERING` instead of a six-outcome label.
+
+**Operational constraints on permitted calls:**
+
+- **Templated**, with a fixed prompt + schema per classification task. No free-form prompts constructed at runtime from unbounded input.
+- **Bounded**, with explicit input-size caps. A thread longer than the cap is truncated around the latest comment with a note, or escalated if truncation would lose necessary context.
+- **Cacheable** by (prompt version, input hash). The same thread classified twice returns the same label unless the prompt version rolls.
+- **Auditable.** Every templated call logs an [ADR 0006](0006-llm-observability.md) event with the template name, input hash, output label, confidence, and classifier version.
+- **Deterministic fallback.** Every template has a deterministic default for total failure (network error, model returns nothing): typically escalate to Engineering or surface `HUMAN-PAUSE`, never silently pick a label.
+
+**Tripwire.** A classifier template that starts returning free-form text, taking actions on its own, or producing outputs outside its declared schema is a drift signal and should be rolled back.
+
+The charter's shorthand — "reading comprehension on free text → narrow templated LLM call inside scaleforce; codebase reasoning → Engineering" — is the principle. This section is the operational detail.
+
 ### Consequences
 
 - Good: aligns with working implementation rather than reinventing it. Skill and ADR stay in sync by construction.

--- a/docs/adr/0006-llm-observability.md
+++ b/docs/adr/0006-llm-observability.md
@@ -1,0 +1,104 @@
+# 0006. LLM observability: structured agent-event logs now, tracing vendor deferred
+
+- **Status**: proposed
+- **Date**: 2026-04-19
+- **Deciders**: @thomHayner
+- **Tags**: observability, bots, orchestration
+
+## Context and Problem Statement
+
+This repo runs an "AI agency" pattern: `claude[bot]`, `copilot-pull-request-reviewer[bot]`, and `scaleforce[bot]` coordinate on PRs, with more agents likely to follow (see [ADR 0003](0003-bot-identity-separation.md), [ADR 0005](0005-copilot-reviewer-loop.md)). When something goes wrong — a review loop that won't converge, a bot posting under the wrong identity, a PR that stalls — we currently have no single place to look. Each signal lives in a different surface: GitHub Actions logs for Claude Code Action runs, webhook delivery logs for `scaleforce[bot]`, PR timelines for Copilot.
+
+The question: do we need an LLM observability tool (Langfuse, Helicone, Arize, LangSmith) now?
+
+Framing matters. The LLM calls themselves happen inside the Claude Code Action and Copilot — vendor-hosted surfaces we don't control. What we *do* control and need to see is the **orchestration layer**: which agent acted, on which PR, why, and with what outcome. That's agent-event telemetry, not prompt-trace telemetry.
+
+## Decision Drivers
+
+- No self-hosted inference path yet. The Anthropic API isn't called from our own code; it's called inside the Claude Code Action. A prompt-trace tool would see nothing.
+- The live operational risk is [ADR 0005](0005-copilot-reviewer-loop.md)'s review loop: we need to know if it's converging, and at which iteration a given PR sits.
+- Identity attribution is load-bearing (see [CLAUDE.md](../../CLAUDE.md)). Knowing *who posted what* after the fact needs to be easy.
+- Small repo, one maintainer. Vendor overhead (accounts, keys, dashboards, bills) should be justified by a question we can't answer without it.
+- Whatever we pick should extend as new agents join without a rewrite.
+
+## Considered Options
+
+- **Option A: adopt an LLM tracing vendor now** (Langfuse / Helicone / LangSmith). Wire up trace ingestion from `scaleforce[bot]` and any future inference paths.
+- **Option B: structured JSON event logs from `scaleforce[bot]`**, emitted to stdout and collected by whatever hosts probot (Fly/Vercel/Railway logs). No vendor. Schema versioned in-repo.
+- **Option C: do nothing; rely on GitHub audit log + Actions logs.** Grep when needed.
+- **Option D: hybrid** — Option B now, revisit a vendor when we have a self-hosted inference path worth tracing.
+
+## Decision Outcome
+
+Chosen: **Option D**.
+
+Implement Option B immediately. Revisit vendor tooling when (a) this repo or a downstream service calls the Anthropic API directly, or (b) event-log volume makes grep-and-jq painful.
+
+### What `scaleforce[bot]` logs
+
+One JSON line per orchestration event, stdout:
+
+```json
+{
+  "ts": "2026-04-19T14:22:31Z",
+  "schema": "scaleforce.event.v1",
+  "event": "copilot_review_received",
+  "pr": "thomHayner/AIHawk_Birdwatcher#42",
+  "actor": "copilot-pull-request-reviewer[bot]",
+  "loop_iteration": 3,
+  "outcome": "comments_present",
+  "comment_count": 2,
+  "latency_ms": 18400,
+  "correlation_id": "pr-42-loop-3"
+}
+```
+
+Event types to cover at minimum:
+- `review_requested` — `scaleforce[bot]` asked Copilot to review.
+- `copilot_review_received` — review came back; carries `comment_count` and loop iteration.
+- `author_pinged` / `maintainer_escalated` — routing decisions from [ADR 0005](0005-copilot-reviewer-loop.md).
+- `loop_exited` — zero-comments exit, with total iterations.
+- `loop_capped` — iteration 7 reached; human breakpoint.
+
+Schema lives in the probot repo alongside the code that emits it. Bump `schema` field on breaking changes.
+
+### What we don't log (yet)
+
+- Prompt contents or model responses. The Claude Code Action handles its own LLM I/O and we don't have a clean hook into it.
+- Token counts or cost. Not ours to measure until we call the API directly.
+- Copilot's review text. GitHub already stores it on the PR; duplicating is noise.
+
+### Consequences
+
+- Good: answers the questions we actually have today (is the review loop healthy? who acted when?) without standing up a vendor.
+- Good: the event stream is a natural input to a tracer later — when we adopt Langfuse or similar, these events become spans in a parent trace.
+- Good: schema-in-repo means agents reading [`llm-wiki/`](../../llm-wiki/) can reason about the event shape.
+- Bad: no prompt-level visibility. If Claude Code Action produces a weird review or wrong code, we'll still be reading Actions logs by hand.
+- Bad: stdout JSON only goes as far as the host's log retention. If we need history beyond that, we'll need to ship logs somewhere (Axiom, Grafana Cloud, S3+Athena) — deferred until the need is real.
+- Neutral: revisit trigger is concrete — self-hosted inference path or log-volume pain. Not a vague "someday."
+
+## Pros and Cons of the Options
+
+### Option A: vendor tracing now
+- Good: batteries-included dashboards, prompt replay, cost tracking.
+- Bad: nothing to trace today. The LLM calls are inside vendor-hosted agents; we'd be paying for an empty dashboard.
+- Bad: another account, key, and bill to manage for a one-maintainer repo.
+
+### Option B: structured event logs (standalone)
+- Good: cheap, in our control, schema versioned with the code.
+- Good: directly answers the [ADR 0005](0005-copilot-reviewer-loop.md) "is the loop converging?" question.
+- Bad: no prompt-level visibility. Won't help debug *why* an agent produced a bad output.
+
+### Option C: do nothing
+- Good: zero work.
+- Bad: review-loop health is currently invisible; we won't notice pathological loops until the 7-iteration cap fires.
+
+### Option D: hybrid (chosen)
+- Good: does the cheap useful thing now; keeps the door open for the expensive useful thing when it's justified.
+- Bad: requires us to actually revisit when triggers hit — needs to show up on the roadmap, not be forgotten.
+
+## More Information
+
+- [ADR 0003](0003-bot-identity-separation.md) — identity separation; log `actor` field maps to these identities.
+- [ADR 0005](0005-copilot-reviewer-loop.md) — the review loop whose health these events measure.
+- Revisit triggers: (a) any service in this org starts calling the Anthropic API directly, or (b) `scaleforce[bot]` event volume exceeds ~1k/day or host log retention stops being sufficient.

--- a/docs/adr/0008-engineering-branch-scaleforce-instrument.md
+++ b/docs/adr/0008-engineering-branch-scaleforce-instrument.md
@@ -1,0 +1,103 @@
+# 0008. Engineering is the branch; scaleforce[bot] is its GitHub instrument
+
+- **Status**: proposed
+- **Date**: 2026-04-22
+- **Deciders**: @thomHayner
+- **Tags**: tree-position, bots, orchestration, scope
+
+## Context and Problem Statement
+
+Earlier ADRs ([0003](0003-bot-identity-separation.md), [0005](0005-copilot-reviewer-loop.md), [0007](0007-github-function-routing.md)) describe `scaleforce[bot]` from the inside — how it posts, how it routes, how it runs the Copilot review loop. They do not say *where it sits in the agency tree* or *who invokes it*. That framing worked while the tree was a single node. It stops working as soon as honeycrisp (Chief-of-Staff router) and sibling domain branches (PersonalOS, Agency, and an Engineering branch) become real.
+
+A direct question surfaced the ambiguity: *if scaleforce is described as "just a router" with no domain opinions, is it really a peer branch alongside PersonalOS and Agency, or is it an instrument that a real Engineering branch uses?*
+
+Applying the test used for other branches: **does it have domain knowledge and opinions?**
+
+- PersonalOS has opinions about *time* — calendars, reminders, attention.
+- Agency has opinions about *people* — customers, team, CRM state.
+- A real Engineering branch would have opinions about the *codebase* — architectural preferences, convention, ownership, change propagation.
+
+`scaleforce[bot]` has none of those. Its expertise is *how GitHub works* — webhooks, identities, fan-out mechanics, terminal states, review-loop state. Those are facts-about-the-instrument, not facts-about-the-user's-engineering. scaleforce is a **GitHub expert**, not an **engineering expert**.
+
+## Decision Drivers
+
+- Each branch of the tree is capped at a 6–10 sub-concern fan-out budget; "scaleforce" and "Engineering" as peers would double-count the engineering slot and waste a branch.
+- Cross-repo synthetic moderation (choosing between legitimate conflicting repo positions) requires codebase reasoning. Assigning that to scaleforce was always a scope violation — the charter's "multiplex-not-moderate" rule is the symptom, not the solution.
+- scaleforce needs someone *above* it in the tree to direct fan-out, approve novel classifications, and moderate synthetic decisions. A peer branch has no one to hand those to except honeycrisp, which is the wrong altitude — honeycrisp is cross-domain, not engineering-specific.
+- Per-repo wiki-agents already exist as sub-concerns of "the engineering domain." They need a branch home; "scaleforce's neighbors" is not that home because scaleforce is an instrument, not a domain owner.
+- The instrument framing matches how PersonalOS uses its Gmail/Calendar MCPs and how Agency uses its CRM MCP. Symmetry across the tree is easier to reason about than a special case.
+
+## Considered Options
+
+- **Option A: scaleforce as a peer branch** alongside PersonalOS, Agency, etc. The original framing. Leaves no branch owner for per-repo wiki-agents and forces scaleforce to either do synthetic reasoning (scope violation) or refuse it (leaves no one to do it).
+- **Option B: scaleforce as Engineering's instrument; Engineering is the branch.** Engineering owns the domain and the 6–10 sub-concern budget; scaleforce implements Engineering's GitHub-surface operations. Per-repo wiki-agents are Engineering's sub-concerns, invoked through scaleforce as the fan-out instrument.
+- **Option C: fold scaleforce directly into Engineering** as the LLM-wiki's own execution tool, no separate identity. Rejected — breaks [ADR 0003](0003-bot-identity-separation.md), kills the GitHub-level audit trail, and conflates reasoning with execution.
+
+## Decision Outcome
+
+Chosen: **Option B.**
+
+**Engineering is the branch.** It is an LLM-wiki at the tree level, peer to PersonalOS, Agency, and the other domain branches under honeycrisp. Engineering reasons about the user's codebase across all repos: architectural calls, ownership, convention, cross-repo decisions, priority-across-the-engineering-queue, novel classification, synthetic moderation.
+
+**`scaleforce[bot]` is Engineering's GitHub instrument.** It provides the fast, deterministic GitHub-surface layer that Engineering uses to execute. Its domain is GitHub end-to-end — webhooks, writes, loops, scaffolding, identity enforcement, the notification-gap sweep — and its thesis is deterministic-fast-path-with-narrow-templated-LLM-classification-where-unavoidable (see [ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary)).
+
+### What moves where
+
+| Concern | Owner | Notes |
+|---|---|---|
+| Codebase reasoning, architectural judgment | Engineering | Always. Never scaleforce. |
+| Which repos are in scope for a cross-repo question | Engineering (novel/ambiguous) or scaleforce (deterministic refs) | See [ADR 0009](0009-ordered-cross-repo-deliberation.md) for the split. |
+| Synthetic moderation of cross-repo conflicts | Engineering | scaleforce does mechanical moderation only. |
+| Mechanical moderation (agreement detection, tie-breaker rules, vote counts, duplicate consolidation) | scaleforce | Configured rules; no reasoning required. |
+| Routing policy (which handler owns which slot) | Config, authored by Engineering or the maintainer | scaleforce *implements*. See [ADR 0007](0007-github-function-routing.md). |
+| Routing execution | scaleforce | Read the table, dispatch. |
+| Review-loop orchestration | scaleforce | [ADR 0005](0005-copilot-reviewer-loop.md). |
+| Scaffolding and convention enforcement | scaleforce | Templates in the orchestrator repo; scaleforce propagates. |
+| Notification-gap monitoring | scaleforce | Issues, Discussions, Projects, stale PRs — scheduled sweeps. |
+| Per-repo wiki-agent invocation | scaleforce, directed by Engineering | Engineering names the targets; scaleforce carries the packets. |
+
+### scaleforce is a long-running deterministic instrument, not a passive MCP
+
+scaleforce is more active than a typical MCP. It wakes on webhooks, runs bounded autonomous loops (review loops, cross-repo deliberation turn-taking, notification sweeps), maintains state on PRs between events, and calls back to Engineering at decision points rather than being re-invoked step-by-step. Classifying it as an instrument does not imply passivity — it implies *who directs it* and *who owns the reasoning*. Engineering kicks off a loop; scaleforce runs it to terminal state, asking Engineering for judgment only when a classification falls outside the narrow-templated-LLM budget.
+
+### Consequences
+
+- Good: clears the ambiguity in [ADR 0003](0003-bot-identity-separation.md), [ADR 0005](0005-copilot-reviewer-loop.md), and [ADR 0007](0007-github-function-routing.md) about who scaleforce answers to.
+- Good: per-repo wiki-agents have a branch home (Engineering's sub-concerns) without creating a new peer slot in the tree.
+- Good: scaleforce's fan-out budget (six ADR 0007 slots + pr-triage) stops being a tree-level concern and becomes an instrument-capacity concern — different conversation, lower stakes.
+- Good: symmetry with how PersonalOS uses Gmail/Calendar MCPs and Agency uses its CRM MCP. Instrument/branch is now the consistent pattern across the tree.
+- Good: enables [ADR 0009](0009-ordered-cross-repo-deliberation.md) — the ordered-cross-repo-deliberation protocol needs a synthetic moderator, which is Engineering, which this ADR names.
+- Bad: the existing ADRs read slightly awkwardly until they're touched up. [ADR 0003](0003-bot-identity-separation.md) is revised in the same PR to add two-layer actor provenance (GitHub identity + upward event-log identity); [ADR 0005](0005-copilot-reviewer-loop.md) is revised to add the classifier-boundary section.
+- Neutral: Engineering's internal structure (which sub-concerns, which per-repo wiki-agents, how it stores knowledge) is out of scope for this ADR. This ADR names the role, not the implementation.
+
+## Pros and Cons of the Options
+
+### Option A: scaleforce as peer branch
+- Good: matches how I initially described scaleforce; nothing moves.
+- Bad: no synthetic moderator above it. Every cross-repo conflict escalates to honeycrisp or the maintainer, which is the wrong altitude.
+- Bad: per-repo wiki-agents have no branch home.
+- Bad: invites scope creep — a peer branch that "just routes" is already fighting gravity.
+
+### Option B: scaleforce as Engineering's instrument (chosen)
+- Good: clean split between reasoning (branch) and execution (instrument).
+- Good: symmetric with other branches' instrument patterns.
+- Good: per-repo wiki-agents, scaffolding convention, notification-sweep policy all have a natural owner.
+- Bad: requires revisions to existing ADRs (0003, 0005) to align. Done in the same PR.
+
+### Option C: fold scaleforce into Engineering
+- Good: single node instead of two; simplest.
+- Bad: destroys [ADR 0003](0003-bot-identity-separation.md)'s actor-provenance invariant — GitHub writes can't distinguish "Engineering reasoned" from "Engineering dispatched a webhook handler."
+- Bad: conflates reasoning latency with execution latency; the deterministic fast-path thesis disappears.
+- Bad: GitHub App scoping becomes a mess (an LLM-wiki branch isn't a GitHub App).
+
+## More Information
+
+- [Charter](../CHARTER.md) — the drop-in scope statement this ADR backs.
+- [ADR 0003](0003-bot-identity-separation.md) — GitHub-level identity separation; revised in the same PR for tree-level two-layer attribution.
+- [ADR 0005](0005-copilot-reviewer-loop.md) — Copilot review loop; revised in the same PR to add the classifier-boundary section.
+- [ADR 0007](0007-github-function-routing.md) — slot routing; this ADR clarifies that routing *policy* is Engineering's (expressed in config) while routing *execution* is scaleforce's.
+- [ADR 0009](0009-ordered-cross-repo-deliberation.md) — ordered cross-repo deliberation protocol; depends on this ADR for the synthetic-moderator role.
+- Related reading for the instrument-vs-branch pattern:
+  - LangGraph multi-agent supervisor / hierarchical teams — https://langchain-ai.github.io/langgraph/tutorials/multi_agent/hierarchical_agent_teams/
+  - AutoGen AgentChat teams — https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html
+  - CrewAI processes — https://docs.crewai.com/concepts/processes

--- a/docs/adr/0009-ordered-cross-repo-deliberation.md
+++ b/docs/adr/0009-ordered-cross-repo-deliberation.md
@@ -1,0 +1,159 @@
+# 0009. Ordered cross-repo deliberation: turn-taking, convergence-or-pathology, mechanical vs synthetic moderation
+
+- **Status**: proposed
+- **Date**: 2026-04-22
+- **Deciders**: @thomHayner
+- **Tags**: orchestration, cross-repo, multi-agent, moderation
+
+## Context and Problem Statement
+
+Some questions touch multiple repos — a distributed-monorepo case where frontend, backend, a service, and a feature repo each own a piece of the answer. Each repo has its own wiki-LLM agent ([ADR 0008](0008-engineering-branch-scaleforce-instrument.md) names per-repo wiki-agents as sub-concerns of the Engineering branch). When a Discussion or issue needs input from 2–3 of them, the naive pattern is to fan out in parallel and collect answers.
+
+Parallel fan-out is the wrong primitive. Observed failure modes:
+
+- **Content dumps.** Each agent answers from its own full context without seeing the others' concerns. The aggregated output is N unrelated essays, not a deliberation.
+- **Duplicate concerns.** Two agents independently raise the same worry with slightly different framing. The consumer has to dedupe.
+- **Conflict without structure.** When agents disagree, there's no structured path from "we disagree" to "here's a decision or a named blocker."
+- **No convergence signal.** Parallel collection has no natural terminator except a timeout. Loops don't converge; they expire.
+
+A better pattern is ordered turn-taking with a moderator, bounded per round, continued until convergence or pathology. `scaleforce[bot]` is well-suited to the *machinery* of this protocol (turn order, round bounds, collection, posting structured summaries, detecting pathology) but not to the *synthetic judgment* of moderating the deliberation itself. [ADR 0008](0008-engineering-branch-scaleforce-instrument.md) places scaleforce as Engineering's instrument; that split lets Engineering play the moderator while scaleforce plays the turn-taking machinery.
+
+## Decision Drivers
+
+- Multi-agent deliberation is a known pattern in the literature (LangGraph supervisor, AutoGen GroupChatManager, CrewAI hierarchical process). Reinventing it badly is unnecessary; adapting an ordered-turn-taking protocol is not novel.
+- The [ADR 0005](0005-copilot-reviewer-loop.md) non-convergence rule (pattern-based, not counter-based) generalizes — the same signal is what catches a stuck deliberation across repos.
+- Scaleforce's identity as a fast deterministic instrument means turn-taking, round bounds, and summary assembly belong to it; synthetic decisions belong to Engineering.
+- Round caps are the wrong primary terminator. Productive deliberations can run 5–10 rounds and resolve; unproductive ones get stuck in 2. Pattern detection is the real signal; a hard cap is only a runaway-protection tripwire.
+- Per-round bounds on *agent output* (concerns per round, words per concern) are load-bearing — without them, the first agent dumps everything and the rest react to a wall of text.
+
+## Considered Options
+
+- **Option A: parallel fan-out.** Collect in parallel, scaleforce aggregates side-by-side, Engineering synthesizes once. The starting point; fails on duplicates, conflicts, and convergence.
+- **Option B: ordered turn-taking, bounded per round, unlimited rounds until convergence or pathology** (chosen). Each agent goes in a determined order within a round, sees prior agents' output in that round, produces bounded output. Moderator synthesizes between rounds. Termination = convergence OR pathology; no fixed round cap; hard backstop at ~25 rounds for runaway protection.
+- **Option C: full group-chat free-for-all** (AutoGen-style open `GroupChatManager` with a speaker-selection LLM). Powerful but hard to bound; speaker selection is itself synthetic reasoning that Engineering would have to own. Rejected as heavier than needed for the distributed-monorepo case.
+- **Option D: tournament / pairwise** (agents argue pairwise, winners advance). Over-engineered for 2–4-repo questions.
+
+## Decision Outcome
+
+Chosen: **Option B.**
+
+### The protocol
+
+**Phase 0 — Scoping.** Engineering (or scaleforce on deterministic references like `owner/repo#123` and explicit labels) identifies the set of participating repos. If the classification is ambiguous or novel, it escalates to Engineering rather than guessing ([ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary)). The output is an ordered list of participants (alphabetical by repo name, or by CODEOWNERS priority, or by who was tagged first — the ordering is configurable but deterministic).
+
+**Phase 1 — Round 1: Concerns (bounded).** scaleforce posts the packet to each repo-wiki-agent with an explicit bound: configurable caps (default: ≤3 concerns, ≤200 words each, no recommendations yet). Agents respond **one at a time in the determined order** — scaleforce holds back agent N+1 until agent N has posted. Each agent sees the prior agents' concerns before speaking, which kills redundancy.
+
+**Phase 2 — Moderator pass.** A moderator synthesizes the concerns and either:
+
+- (a) **proposes a tentative decision** with rationale, or
+- (b) **identifies what cannot yet be decided** and asks a targeted follow-up of one or more specific agents.
+
+The moderator is **Engineering** by default. honeycrisp may substitute if Engineering is absent; the maintainer may substitute for either.
+
+scaleforce does NOT play moderator here — moderation is synthetic (see Mechanical vs synthetic split below).
+
+**Phase 3 — Round 2+: Reactions.** scaleforce posts the moderator's output back to each agent, in the same ordering, with the same per-round bounds. Each agent agrees / objects / refines against the moderator's proposal. Agents see prior agents' reactions before speaking.
+
+**Phase 4 — Convergence check.** After each round:
+
+- **Converged** if all agents agree with the moderator's current proposal, or if remaining objections are explicitly within the moderator's acceptable scope.
+- **Continue** if new concerns surfaced that the moderator wants to take another pass on.
+- **Pathology** (see below) if the loop is stuck.
+
+On convergence: scaleforce posts a final structured summary, labels the Discussion/issue `cross-repo-converged`, and hands off to the relevant handler or the maintainer.
+
+### Termination — convergence, pathology, or runaway backstop
+
+Termination follows the same taxonomy as [ADR 0005](0005-copilot-reviewer-loop.md#termination):
+
+- **Convergence** — per above.
+- **Maintainer intervention** — stop signal, takeover, explicit decision.
+- **Pathology** — "same class of concern recurring with no progress for 3 rounds in a row." Reuses [ADR 0005](0005-copilot-reviewer-loop.md#termination)'s non-convergence rule, applied at the deliberation-class level rather than the thread-class level. Triggers `HUMAN-PAUSE`.
+- **Hard backstop** at ~25 rounds, purely runaway protection for unattended deliberations. Triggers `HUMAN-PAUSE`. Should almost never fire; if it does, either the pathology detector is too lenient or the bounds-per-round are too loose.
+
+**There is no fixed productive-round cap.** A deliberation that runs 7 productive rounds and resolves is a success. Round count is telemetry, not a terminator.
+
+### Mechanical vs synthetic moderation — the split
+
+scaleforce may do **mechanical moderation**:
+
+- **Agreement detection** — all agents' Round-N responses match by a deterministic comparator.
+- **Duplicate consolidation** — agents raised concerns with high keyword overlap; collapse into one bullet in the round summary.
+- **Vote counts** — when a configured majority-rules tie-breaker applies.
+- **Configured tie-breaker rules** — e.g., "frontend wins on UX calls, backend wins on data-model calls"; scaleforce recognizes the class of call from labels and applies the rule.
+- **Bound enforcement** — rejecting an agent's output for exceeding the round's concern/word caps, with a templated ask to retry.
+
+scaleforce may NOT do **synthetic moderation**:
+
+- Choosing between legitimate conflicting positions based on codebase judgment.
+- Deciding whether a tentative proposal adequately addresses a concern.
+- Extending scope ("maybe we should also consider…").
+- Writing the rationale for a decision.
+
+Synthetic moderation is always Engineering's, even if scaleforce's internal classifier *could* produce a plausible answer. The classifier boundary ([ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary)) permits classification from free text into a fixed taxonomy; moderation is not that.
+
+### Fan-out budget
+
+- **≤ 10 repos per deliberation.** A question that genuinely touches more than 10 repos is `HUMAN-PAUSE` on principle; no agent (or moderator) should decide that broadly in one pass. This matches the tree's 6–10 rule at the deliberation level.
+- Within a deliberation, ordering is determined in Phase 0 and held stable across all rounds. No mid-deliberation reordering.
+
+### Actor provenance (two-layer)
+
+Every round-summary post is written under `scaleforce[bot]`'s installation token (GitHub layer). The moderator's rationale, when it appears in a summary, is attributed in the summary body to its author (Engineering, honeycrisp, or the maintainer) and in the [ADR 0006](0006-llm-observability.md) event log's `decided_by` field. Agents' outputs are attributed to their own repo-wiki-agent identity. See [ADR 0003 § Tree-level attribution](0003-bot-identity-separation.md#tree-level-attribution-upward-identity).
+
+### Event-log shape
+
+Each phase emits a structured event:
+
+- `deliberation_opened` — scoping result, participant list, ordering, bounds.
+- `round_started` — round index, phase (concerns | reactions).
+- `agent_spoke` — per-agent, with classification of their output (concern / objection / refinement / agreement).
+- `moderator_pass` — moderator identity, output type (tentative_decision | targeted_followup).
+- `round_ended` — round index, convergence-check result.
+- `deliberation_closed` — reason (converged | pathology | hard_backstop | maintainer).
+
+honeycrisp's view of an in-flight cross-repo deliberation is assembled entirely from these events.
+
+### Consequences
+
+- Good: formalizes a pattern that was implicit and already drifting toward ad-hoc implementation.
+- Good: reuses [ADR 0005](0005-copilot-reviewer-loop.md)'s pathology-detection rule at a new level, minimizing new vocabulary.
+- Good: mechanical-vs-synthetic split gives a principled place to say no when scaleforce is tempted to reason.
+- Good: bounded per-round output prevents content-dump failure mode.
+- Good: hard backstop at ~25 rounds catches runaway loops without punishing productive ones.
+- Bad: more machinery than the single-agent review loop; scaleforce's state model grows (per-deliberation state, per-round state, per-agent-turn state). Mitigation: state is derivable from the event log plus the Discussion/issue thread — stateless-per-event Probot still works.
+- Bad: the moderator role creates a new always-on expectation on Engineering. Without Engineering, `honeycrisp` substitutes; without honeycrisp, the maintainer substitutes; otherwise the deliberation cannot proceed. Documented as acceptable.
+- Neutral: ordering rule (alphabetical / CODEOWNERS / tagged-first) is configurable, not opinionated. Orgs can choose.
+
+## Pros and Cons of the Options
+
+### Option A: parallel fan-out
+- Good: simplest to implement.
+- Bad: content dumps, duplicate concerns, no structured conflict path, no convergence signal.
+
+### Option B: ordered turn-taking, unlimited rounds until convergence or pathology (chosen)
+- Good: each agent sees prior turns; reduces redundancy and reactivity.
+- Good: pathology detection reuses [ADR 0005](0005-copilot-reviewer-loop.md)'s rule — one vocabulary.
+- Good: productive long deliberations are not penalized.
+- Bad: requires a moderator that can speak between rounds. Mitigated by Engineering being present by design.
+
+### Option C: open group-chat with speaker-selection LLM
+- Good: expressive; handles novel deliberation shapes.
+- Bad: speaker-selection LLM is itself a synthetic reasoner inside scaleforce, which violates [ADR 0008](0008-engineering-branch-scaleforce-instrument.md).
+- Bad: harder to bound; hard to detect pathology.
+
+### Option D: pairwise tournament
+- Good: deterministic ordering by construction.
+- Bad: over-engineered for 2–4-repo questions; pairwise framing loses information when 3 agents need to converge on a single point.
+
+## More Information
+
+- [Charter](../CHARTER.md) — item 2 of "What scaleforce does" names this protocol.
+- [ADR 0005](0005-copilot-reviewer-loop.md) — pathology-detection rule reused here; classifier boundary bounds the LLM calls the protocol may make inside scaleforce.
+- [ADR 0007](0007-github-function-routing.md) — cross-repo deliberation is not a slot; it's a protocol invoked within the `discussions` / `issues` / `pr-reviews` slots when scope is multi-repo.
+- [ADR 0008](0008-engineering-branch-scaleforce-instrument.md) — establishes Engineering as the synthetic-moderator owner.
+- Related reading:
+  - LangGraph hierarchical agent teams: https://langchain-ai.github.io/langgraph/tutorials/multi_agent/hierarchical_agent_teams/
+  - LLM-as-a-Judge (Zheng et al.): https://arxiv.org/abs/2306.05685
+  - AutoGen AgentChat teams: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html
+  - CrewAI processes: https://docs.crewai.com/concepts/processes

--- a/docs/adr/0009-ordered-cross-repo-deliberation.md
+++ b/docs/adr/0009-ordered-cross-repo-deliberation.md
@@ -157,3 +157,7 @@ honeycrisp's view of an in-flight cross-repo deliberation is assembled entirely 
   - LLM-as-a-Judge (Zheng et al.): https://arxiv.org/abs/2306.05685
   - AutoGen AgentChat teams: https://microsoft.github.io/autogen/stable/user-guide/agentchat-user-guide/tutorial/teams.html
   - CrewAI processes: https://docs.crewai.com/concepts/processes
+
+## Open research
+
+- **Robert's New Rules of Order (RNRO)** — research as a source of moderation strategies for the Phase-2 moderator pass and the mechanical-vs-synthetic split. Specifically: motion handling, amendment ordering, calling the question, and tabling rules may translate into deterministic mechanical-moderation primitives that scaleforce can apply without escalating to Engineering. Action: produce a follow-up note (or a successor ADR) mapping RNRO procedures onto this protocol's round/phase model before broadening mechanical-moderation scope.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,4 +20,7 @@ See [`template.md`](template.md) — copy it for new ADRs.
 - [0003](0003-bot-identity-separation.md) — Separate bot identities for orchestration vs. AI work
 - [0004](0004-docs-tree-over-github-wiki.md) — Use `docs/` tree instead of GitHub Wiki
 - [0005](0005-copilot-reviewer-loop.md) — Copilot-reviewer loop: terminal-state invariant, triage taxonomy, anchor on `copilot-recursive-review` skill
+- [0006](0006-llm-observability.md) — LLM observability: structured agent-event logs now, tracing vendor deferred
 - [0007](0007-github-function-routing.md) — GitHub function routing: cascading defaults with per-function overrides
+- [0008](0008-engineering-branch-scaleforce-instrument.md) — Engineering is the branch; scaleforce[bot] is its GitHub instrument
+- [0009](0009-ordered-cross-repo-deliberation.md) — Ordered cross-repo deliberation: turn-taking, convergence-or-pathology, mechanical vs synthetic moderation


### PR DESCRIPTION
## Summary

Adds an **Open research** section to ADR 0009 flagging Robert's New Rules of Order (RNRO) as a candidate source of moderation strategies — particularly whether motion handling, amendment ordering, calling the question, and tabling rules can become deterministic mechanical-moderation primitives that scaleforce can apply without escalating to Engineering.

## Related

- ADR: \`docs/adr/0009-ordered-cross-repo-deliberation.md\`

## Test plan

- [x] Docs-only change; no code touched
- [x] Markdown renders (heading nests under existing structure, no broken links introduced)

## Checklist

- [x] One logical change per PR
- [x] CLAUDE.md / AGENTS.md rules respected
- [x] If architecture-affecting: ADR added or updated — ADR 0009 amended in place (research note, not a decision change)
- [x] If new dependency: justified in Summary — n/a
- [x] If touching \`llm-wiki/\`-relevant knowledge: wiki updated — n/a (no wiki entry references this section yet)

## Notes for reviewer

The action item is intentionally a follow-up note or successor ADR rather than baking RNRO into 0009 — the current ADR's mechanical-vs-synthetic split shouldn't drift on a research hunch. Calling it out here so the question doesn't get lost.