### PR TITLE
feat(llm): add config-driven multi-provider portal at src/llm/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Agents have distinct identities **on purpose**. Do not impersonate the maintaine
 5. **One logical change per PR.** Refactors separate from features.
 6. **Read `docs/` before starting nontrivial work**: vision → roadmap → specs → adr.
 7. **Update `llm-wiki/`** when you learn something durable that future agents will need (a non-obvious convention, an integration quirk, a decision rationale not yet in an ADR).
+8. **All LLM calls in handler code go through the portal at [`src/llm/`](src/llm/).** Handlers call `complete(input, opts)`; the portal selects an adapter from config (`LLM_DEFAULT_PROVIDER`, `LLM_HANDLER_<NAME>`) and falls back to a mock when nothing is configured. **Direct vendor SDK imports outside `src/llm/providers/` are a convention violation** — that includes `openai`, `@anthropic-ai/sdk`, etc. Adding a new provider is one adapter file under `src/llm/providers/` plus a registry line. See [`docs/setup/llm-providers.md`](docs/setup/llm-providers.md) and [ADR 0010](docs/adr/0010-llm-provider-portal.md).
 
 ## Where to find things
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,10 @@ Read in this order before starting nontrivial work:
 - For features: include a brief test plan even if tests are added.
 - One logical change per PR. Refactors and feature work go in separate PRs unless impossible.
 
+## LLM calls
+
+All LLM calls in handler code MUST go through the portal at [`src/llm/`](src/llm/). Direct vendor SDK imports (`import OpenAI from "openai"`, `import Anthropic from "@anthropic-ai/sdk"`, etc.) outside `src/llm/providers/` are a convention violation. The portal exposes a single `complete(input, opts)` function with config-driven provider selection; see [`docs/setup/llm-providers.md`](docs/setup/llm-providers.md) and [ADR 0010](docs/adr/0010-llm-provider-portal.md). The classifier-boundary discipline from [ADR 0005](docs/adr/0005-copilot-reviewer-loop.md#classifier-boundary) still applies — the portal is the transport, not a license to relax *what* a call is allowed to decide inside `scaleforce[bot]`.
+
 ## Things to avoid
 
 - Don't introduce new dependencies without a one-line justification in the PR body.

--- a/docs/adr/0010-llm-provider-portal.md
+++ b/docs/adr/0010-llm-provider-portal.md
@@ -1,0 +1,125 @@
+# 0010. LLM provider portal
+
+- **Status**: accepted
+- **Date**: 2026-04-26
+- **Deciders**: @thomHayner
+- **Tags**: architecture, llm, portability
+
+## Context and Problem Statement
+
+Until now, LLM calls inside `scaleforce[bot]` have been hardwired to OpenAI by import location: handlers under `src/completions/` did `import OpenAi from "openai"` and instantiated `new OpenAi({ apiKey: process.env.OPENAI_API_KEY })` at module scope. This has two concrete failure modes:
+
+1. **Module-load crash without the key.** `npm test` fails before any test can run when `OPENAI_API_KEY` is unset, because the constructor throws during import. This blocks the verify discipline (`lint && test && build`) required by the recursive Copilot-review loop ([ADR 0005](0005-copilot-reviewer-loop.md)) for any contributor without an OpenAI key. The crash surfaced during round-1 verify on PR #13 (commit ea43d59) and motivated [#14](https://github.com/thomHayner/scaleforce-github-orchestrator/issues/14).
+2. **Vendor lock-in by import.** Switching a handler from OpenAI to Anthropic / xAI / Vercel v0 / a local model (Ollama, llama.cpp, LM Studio) requires editing the handler's source, not config. There is no place to plug in a fake adapter for tests, no place to declare per-handler routing, and no taxonomy for capability-based routing.
+
+A cleaner fallback key (e.g. `process.env.OPENAI_API_KEY ?? "sk-test"`) papers over the symptom but cements the underlying coupling.
+
+## Decision Drivers
+
+- The verify discipline must work without a vendor key.
+- Provider selection must be config-driven so we can swap vendors per handler without touching handler code.
+- Adding a new vendor must mean writing one adapter file, not touching every handler.
+- The portal must not regress the LLM-call boundary defined in [ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary). Templated-classification discipline is independent of transport.
+- Minimal new runtime dependencies. The bot is small and we want to keep it that way.
+
+## Considered Options
+
+- **Option A: Single shim re-exporting OpenAI.** Move the `new OpenAI(...)` into `src/llm/openai.ts` and re-export. Handlers import from there. Fixes the lazy-construction bug but doesn't address vendor portability or capability routing.
+- **Option B: Vercel AI SDK as the portal.** Adopt `ai` (Vercel) as the abstraction. Breadth of providers, streaming-first ergonomics. But it's a substantial new runtime dependency, opinionated about message shape, and ties our portal evolution to a third-party SDK roadmap.
+- **Option C: Build a thin in-house portal with per-vendor adapters and config-driven selection.** Adapter per vendor in `src/llm/providers/`, lazy SDK construction, capability flags, mock adapter for tests, env-driven config.
+
+## Decision Outcome
+
+Chosen option: **Option C — thin in-house portal**, because it is small enough to read in one sitting, keeps our runtime dependency list minimal (Anthropic and local providers are wired with `fetch`, no new SDK deps), and gives us exactly the integration points we need (lazy construction, capability flags, mock adapter) without coupling our roadmap to a third-party SDK.
+
+### Interface
+
+The portal exposes a single `complete(input, opts)` function plus a small set of types:
+
+```ts
+type LlmMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | { role: "assistant"; content: string | null; toolCalls?: LlmToolCall[] }
+  | { role: "tool"; toolCallId: string; content: string };
+
+interface LlmTool { name: string; description?: string; parameters: Record<string, unknown>; }
+interface CompleteInput { messages: LlmMessage[]; model?: string; tools?: LlmTool[]; temperature?: number; maxTokens?: number; }
+interface CompleteOutput { content: string | null; toolCalls: LlmToolCall[]; finishReason: FinishReason; raw?: unknown; }
+interface CompleteOpts { handler?: string; provider?: ProviderName; requireCapabilities?: Partial<Capabilities>; }
+```
+
+Tools are described as JSON Schema directly so the portal does not depend on Zod or a particular schema library.
+
+### Capability-flag taxonomy
+
+Each adapter declares:
+
+| Flag | Meaning |
+|---|---|
+| `streaming` | Adapter can stream tokens (the portal does not yet expose this; reserved). |
+| `structuredOutput` | Adapter supports JSON-schema-constrained outputs natively. |
+| `toolUse` | Adapter accepts and returns function/tool calls. |
+| `vision` | Adapter accepts image inputs. |
+| `contextWindow` | Approximate context window in tokens (`0` = unknown). |
+
+`complete()` accepts `requireCapabilities` and falls back to `mock` if the resolved provider does not satisfy them. The flag set is intentionally small — large enough for routing decisions, small enough to be honestly reportable per vendor.
+
+### Lazy-construction invariant
+
+Adapters MUST NOT instantiate any vendor SDK client at module load. SDK construction happens inside the first `complete()` call. `isAvailable()` reads env vars only. This is the invariant that prevents the test-time crash from recurring.
+
+### Provider selection
+
+Order of precedence:
+
+1. `opts.provider` — explicit override.
+2. `LLM_HANDLER_<NAME>` env var matching `opts.handler`.
+3. `LLM_DEFAULT_PROVIDER` env var.
+4. `mock` if none of the above is set.
+
+If the resolved provider's `isAvailable()` returns false (e.g. selected `openai` but no `OPENAI_API_KEY`), the portal silently falls back to `mock`. This is intentional for test ergonomics; production should set the keys it expects to use.
+
+### Initial provider matrix
+
+| Provider | Status |
+|---|---|
+| `openai` | wired (lazy SDK init via `import("openai")`) |
+| `anthropic` | wired (Messages REST API, no SDK dep) |
+| `local` | wired (OpenAI-compatible chat-completions via `fetch`; Ollama / llama.cpp / LM Studio / vLLM) |
+| `grok` | stub (xAI exposes an OpenAI-compatible endpoint) |
+| `v0` | stub (v0 exposes an OpenAI-compatible endpoint) |
+| `mock` | always available; default in tests |
+
+Stubs throw on `complete()` so misconfiguration fails loudly.
+
+### Consequences
+
+- Good: `npm test` runs without `OPENAI_API_KEY`. The verify step from [ADR 0005](0005-copilot-reviewer-loop.md) is reachable for every contributor.
+- Good: Provider selection is config, not code. Switching `issuesAi` from OpenAI to Anthropic is `export LLM_HANDLER_ISSUESAI=anthropic`.
+- Good: Adding a new vendor is one adapter file plus a registry line.
+- Good: Mock adapter gives tests a deterministic boundary without mocking the vendor SDK.
+- Bad: The portal's interface is necessarily a subset. Vendor-specific features (e.g. Anthropic prompt caching, OpenAI structured outputs) are not abstracted; adapters expose them via `raw` or via per-vendor extensions. This matches the non-goal in [#14](https://github.com/thomHayner/scaleforce-github-orchestrator/issues/14): we are not building a unified prompt-caching layer.
+- Bad: Two surface areas now (portal + adapters). A vendor SDK update could require an adapter update.
+- Neutral: The portal is the **transport**. The classifier-boundary discipline from [ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary) still applies to *what* an LLM call is allowed to decide inside `scaleforce[bot]` — the portal does not relax it.
+
+## Pros and Cons of the Options
+
+### Option A: Single OpenAI shim
+- Good: Smallest possible change; fixes lazy-construction bug.
+- Bad: Doesn't address vendor portability. The day we want Anthropic, we redo this work.
+
+### Option B: Vercel AI SDK
+- Good: Battle-tested abstraction with broad provider coverage and streaming-first ergonomics.
+- Bad: Substantial new runtime dependency. Opinionated about shape (e.g. message format, tool schemas). Couples our roadmap to a third-party SDK we don't otherwise use.
+
+### Option C: In-house thin portal *(chosen)*
+- Good: Small, readable, exactly the integration points we need. No new runtime SDK deps for Anthropic or local providers.
+- Bad: We own the maintenance. Each new vendor is a small adapter file we have to write and update.
+
+## More Information
+
+- Issue: [#14](https://github.com/thomHayner/scaleforce-github-orchestrator/issues/14)
+- PR where the crash surfaced: [#13](https://github.com/thomHayner/scaleforce-github-orchestrator/pull/13)
+- Provider setup: [`docs/setup/llm-providers.md`](../setup/llm-providers.md)
+- Related: [ADR 0005 § Classifier boundary](0005-copilot-reviewer-loop.md#classifier-boundary), [ADR 0006](0006-llm-observability.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,3 +24,4 @@ See [`template.md`](template.md) — copy it for new ADRs.
 - [0007](0007-github-function-routing.md) — GitHub function routing: cascading defaults with per-function overrides
 - [0008](0008-engineering-branch-scaleforce-instrument.md) — Engineering is the branch; scaleforce[bot] is its GitHub instrument
 - [0009](0009-ordered-cross-repo-deliberation.md) — Ordered cross-repo deliberation: turn-taking, convergence-or-pathology, mechanical vs synthetic moderation
+- [0010](0010-llm-provider-portal.md) — LLM provider portal: thin in-house adapter layer with config-driven selection and lazy SDK construction

--- a/docs/setup/llm-providers.md
+++ b/docs/setup/llm-providers.md
@@ -37,7 +37,7 @@ matters in tests, since CI/prod sets the key explicitly.
 |---|---|---|---|
 | `openai` | wired | `OPENAI_API_KEY` | Lazy SDK init via `import("openai")`. |
 | `anthropic` | wired | `ANTHROPIC_API_KEY` | Implemented against the Messages REST API to avoid an SDK dep. |
-| `local` | wired | `LLM_LOCAL_BASE_URL` (default `http://127.0.0.1:11434/v1`), `LLM_LOCAL_MODEL` (default `llama3.1`) | Any OpenAI-compatible server: Ollama (with `/v1`), llama.cpp `--api`, LM Studio, vLLM. Capability flag `toolUse` is conservatively `false`. |
+| `local` | wired | `LLM_LOCAL_BASE_URL` (default `http://127.0.0.1:11434/v1`), `LLM_LOCAL_MODEL` (default `llama3.1`) | Any OpenAI-compatible server: Ollama (with `/v1`), llama.cpp `--api`, LM Studio, vLLM. **Opt-in:** at least one of these env vars must be set for `isAvailable()` to return true — otherwise the portal falls back to `mock` even when `LLM_DEFAULT_PROVIDER=local`. The defaults above only kick in once you've opted in. Capability flag `toolUse` is conservatively `false`. |
 | `grok` | stub | `XAI_API_KEY` | Throws on use; xAI exposes an OpenAI-compatible endpoint at `https://api.x.ai/v1` — wire when first handler targets it. |
 | `v0` | stub | `V0_API_KEY` | Throws on use; v0's chat completions endpoint at `https://api.v0.dev/v1`. |
 | `mock` | always available | — | Deterministic placeholder. The default for tests. |

--- a/docs/setup/llm-providers.md
+++ b/docs/setup/llm-providers.md
@@ -96,7 +96,7 @@ if (result.finishReason === "tool_calls") {
 
 `opts` accepts:
 
-- `handler` — logical name looked up in `LLM_HANDLER_<NAME>`. Lowercased.
+- `handler` — logical name looked up in `LLM_HANDLER_<NAME>`. Normalized by lowercasing and stripping underscores/dashes, so `issuesai`, `issues_ai`, `issues-ai`, and `LLM_HANDLER_ISSUES_AI` all map to the same handler key.
 - `provider` — explicit override (`"openai"`, `"anthropic"`, ...). Bypasses handler lookup.
 - `requireCapabilities` — `Partial<Capabilities>`; falls back to `mock` if the resolved provider can't satisfy them.
 

--- a/docs/setup/llm-providers.md
+++ b/docs/setup/llm-providers.md
@@ -68,6 +68,11 @@ const myTool: LlmTool = {
 
 const result = await complete(
   {
+    // `model` is provider-specific. The id below is an OpenAI model — when
+    // routing to Anthropic / local / etc., either change this string or
+    // omit it entirely (each adapter falls back to its own DEFAULT_MODEL).
+    // Per-handler model selection is tracked separately; see the issue
+    // backlinked from the LLM portal ADR.
     model: "gpt-4o",
     messages: [
       { role: "system", content: "You are a triage agent." },

--- a/docs/setup/llm-providers.md
+++ b/docs/setup/llm-providers.md
@@ -1,0 +1,104 @@
+# LLM provider portal
+
+The bot routes every LLM call through `src/llm/` — a thin portal in front of
+per-vendor adapters. Handlers call `complete(input, opts)`; the portal picks an
+adapter based on config and falls back to a mock when nothing is configured.
+
+See [ADR 0010](../adr/0010-llm-provider-portal.md) for the rationale.
+
+## Why
+
+Direct `import OpenAI from "openai"` calls in handlers are forbidden because:
+
+1. **Module-load failures.** `new OpenAI({ apiKey: process.env.OPENAI_API_KEY })`
+   at module scope crashes the test runner when no key is present. The portal
+   constructs vendor SDK clients lazily — only when actually invoked.
+2. **Vendor lock-in.** Switching providers (or wiring a new one) should be
+   config, not code.
+3. **Capability routing.** Handlers can ask for "any provider that supports
+   tool use" without naming one.
+
+## Selecting a provider
+
+Two environment variables drive selection:
+
+| Variable | Purpose | Example |
+|---|---|---|
+| `LLM_DEFAULT_PROVIDER` | Global default | `openai`, `anthropic`, `local`, `mock` |
+| `LLM_HANDLER_<NAME>`   | Per-handler override (matches the `handler` arg passed to `complete()`) | `LLM_HANDLER_ISSUESAI=anthropic` |
+
+If unset, the default is `mock`. If a configured provider is unavailable
+(missing key, etc.), the portal falls back to `mock` — silent fallback only
+matters in tests, since CI/prod sets the key explicitly.
+
+## Per-provider env
+
+| Provider | Status | Env vars | Notes |
+|---|---|---|---|
+| `openai` | wired | `OPENAI_API_KEY` | Lazy SDK init via `import("openai")`. |
+| `anthropic` | wired | `ANTHROPIC_API_KEY` | Implemented against the Messages REST API to avoid an SDK dep. |
+| `local` | wired | `LLM_LOCAL_BASE_URL` (default `http://127.0.0.1:11434/v1`), `LLM_LOCAL_MODEL` (default `llama3.1`) | Any OpenAI-compatible server: Ollama (with `/v1`), llama.cpp `--api`, LM Studio, vLLM. Capability flag `toolUse` is conservatively `false`. |
+| `grok` | stub | `XAI_API_KEY` | Throws on use; xAI exposes an OpenAI-compatible endpoint at `https://api.x.ai/v1` — wire when first handler targets it. |
+| `v0` | stub | `V0_API_KEY` | Throws on use; v0's chat completions endpoint at `https://api.v0.dev/v1`. |
+| `mock` | always available | — | Deterministic placeholder. The default for tests. |
+
+## The mock adapter
+
+The mock adapter returns `[mock] <last-user-message-prefix>` and no tool calls.
+Tests should never need a real key; running `unset OPENAI_API_KEY && npx vitest run`
+must succeed. Handlers that depend on a specific tool-call shape should mock
+the portal at the `complete()` boundary rather than the vendor SDK.
+
+## Calling the portal
+
+```ts
+import { complete, type LlmTool } from "../llm/index.js";
+
+const myTool: LlmTool = {
+  name: "addLabel",
+  description: "Apply the chosen primary label.",
+  parameters: {
+    type: "object",
+    required: ["primaryLabel"],
+    properties: {
+      primaryLabel: { type: "string", enum: ["bug", "enhancement"] },
+    },
+  },
+};
+
+const result = await complete(
+  {
+    model: "gpt-4o",
+    messages: [
+      { role: "system", content: "You are a triage agent." },
+      { role: "user", content: "Issue body here..." },
+    ],
+    tools: [myTool],
+  },
+  { handler: "issuesai" },
+);
+
+if (result.finishReason === "tool_calls") {
+  for (const call of result.toolCalls) {
+    /* dispatch */
+  }
+}
+```
+
+`opts` accepts:
+
+- `handler` — logical name looked up in `LLM_HANDLER_<NAME>`. Lowercased.
+- `provider` — explicit override (`"openai"`, `"anthropic"`, ...). Bypasses handler lookup.
+- `requireCapabilities` — `Partial<Capabilities>`; falls back to `mock` if the resolved provider can't satisfy them.
+
+## Adding a new provider
+
+1. Create `src/llm/providers/<name>.ts` exporting an `LlmProvider`.
+2. Implement `isAvailable()` against env vars only — do not instantiate any client.
+3. Implement `complete()` translating to/from the portal's `LlmMessage`/`LlmToolCall` shapes.
+4. Register in `src/llm/registry.ts` and add the name to `ProviderName` in `src/llm/types.ts`.
+5. Update this doc and the ADR's status table.
+
+The portal is the **only** allowed entry point for LLM calls in handler code.
+Direct vendor SDK imports outside `src/llm/providers/` are a convention
+violation — see `CLAUDE.md` and `AGENTS.md`.

--- a/docs/setup/llm-providers.md
+++ b/docs/setup/llm-providers.md
@@ -15,8 +15,12 @@ Direct `import OpenAI from "openai"` calls in handlers are forbidden because:
    constructs vendor SDK clients lazily — only when actually invoked.
 2. **Vendor lock-in.** Switching providers (or wiring a new one) should be
    config, not code.
-3. **Capability routing.** Handlers can ask for "any provider that supports
-   tool use" without naming one.
+3. **Capability checks.** Handlers can require capabilities such as tool use
+   without hard-coding SDK-specific logic; the portal validates the resolved
+   provider against `requireCapabilities` and falls back to `mock` if it
+   doesn't satisfy them. The portal does **not** currently search across
+   providers for one that satisfies the requirement — see
+   `findCapableProvider()` in `src/llm/index.ts` if you need that explicitly.
 
 ## Selecting a provider
 

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -1,15 +1,11 @@
-import OpenAi from 'openai';
-import type { OpenAI } from 'openai/src/index.js';
-import type { Stream } from 'openai/streaming.mjs';
-import { z } from "zod";
-import { zodFunction } from "openai/helpers/zod";
+import { complete } from "../llm/index.js";
+import type { LlmMessage, LlmTool } from "../llm/index.js";
 import {
   primaryLabelList,
   addLabel,
-  fetchRepo as fetchTemplate
 } from '../utils/issuesUtils.js';
 
-const issuesAiClient = new OpenAi({ apiKey: process.env.OPENAI_API_KEY });
+const HANDLER = "issuesai";
 
 const systemPrompt:string = `\
   You are an intelligent Software Engineer working as a GitHub Repository Maintainer on an open source project.\n
@@ -29,7 +25,7 @@ const taskPrompt:string = `\
     - Analyze new issues and triage them.\n
     - If an issue is missing key information, you will ask follow up questions.\n
     - Apply an appropriate primary label to new issues, some issues may have additional secondary labels.\n
-    - Create an official Issue Report based on a template that corresponds with the primary label.\n 
+    - Create an official Issue Report based on a template that corresponds with the primary label.\n
     - Compare new issues to existing issues (both open and closed) to determine if the new issue is a duplicate.\n
     - If a new issue is a duplicate you will add the secondary label "duplicate" and reference the new issue with a comment in the existing issue's conversation.\n
     - Monitor issues and comments for inappropriate language; if an issue or comment contains questionable content you will hide the message from public view and notify human moderators for follow up.\n
@@ -61,76 +57,77 @@ const taskPrompt:string = `\
   3. Call the getReportTemplate function to get the reportTemplate that corresponds with the primaryLabel.\n
   4. Compare the issue comments and the reportTemplate to determine if you have enough information for completing the entire reportTemplate.\n
     - If there is enough information in the issue comments you should respond with an officialReport that conforms to the reportTemplate, otherwise, ask follow up questions until you have all of the necessary information for generating the officialReport.
-  5. After picking a primaryLabel and generating an officialReport, 
+  5. After picking a primaryLabel and generating an officialReport,
 `
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-const addPrimaryLabelParams = z.object({
-  primaryLabel: z.enum([primaryLabelList[0], ...primaryLabelList]).describe("The Primary Label to apply to the Issue."),
-});
+const addPrimaryLabelTool: LlmTool = {
+  name: "addLabel",
+  description: "Apply the chosen primary label to the issue.",
+  parameters: {
+    type: "object",
+    additionalProperties: false,
+    required: ["primaryLabel"],
+    properties: {
+      primaryLabel: {
+        type: "string",
+        enum: [...primaryLabelList],
+        description: "The Primary Label to apply to the Issue.",
+      },
+    },
+  },
+};
 
-const addPrimaryLabelTools = [
-  zodFunction({ name: "addLabel", parameters: addPrimaryLabelParams }),
-];
-
-// const reportTemplate = z.object({
-//   name: z.enum([primaryLabelList[0], ...primaryLabelList]).describe("The template for the Official Report that corresponds with primaryLabel."),
-// });
-// const generateReportTools = [
-//   zodFunction({ name: "fetchTemplate", parameters: addPrimaryLabelParams }),
-// ];
+function buildBaseMessages(context: any, extra: any[]): LlmMessage[] {
+  const issue = context.payload.issue;
+  const labels = issue.labels && issue.labels.length > 0
+    ? 'Labels: ' + issue.labels.map((n: any) => n.name + ', ') + ' '
+    : '';
+  return [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: taskPrompt },
+    { role: 'user', content: `${labels}${issue.title}: ${issue.body}` },
+    ...extra,
+  ];
+}
 
 export async function primaryLabelCompletion(context:any, messageList:any) {
-  const issue = context.payload.issue;
+  const messages = buildBaseMessages(context, messageList);
 
-  // Give the AI it's prompts and the new Issue:
-  const params:OpenAI.Chat.ChatCompletionCreateParams = {
-    model: 'gpt-4o',
-    messages: [
-      {
-        role: 'system',
-        content: systemPrompt,
-      },
-      {
-        role: 'user',
-        content: taskPrompt,
-      },
-      {
-        role: 'user',
-        content: `${(issue.labels && issue.labels.length > 0) ? 'Labels: ' + issue.labels.map((n:any) => n.name + ', ') + ' ' : ''}${issue.title}: ${issue.body}`,
-      },
-      ...messageList
-    ],
-    tools: addPrimaryLabelTools,
-  };
-  const chatCompletion:Stream<OpenAi.Chat.Completions.ChatCompletionChunk> | OpenAi.Chat.Completions.ChatCompletion = await issuesAiClient.chat.completions.create(params);
-  let aiResponse:string = "";
+  const first = await complete(
+    {
+      model: 'gpt-4o',
+      messages,
+      tools: [addPrimaryLabelTool],
+    },
+    { handler: HANDLER },
+  );
 
-  // If the AI can decide on a Primary Label
-  if (chatCompletion.choices[0].finish_reason === "tool_calls" && chatCompletion.choices[0].message.tool_calls?.[0].function) {
-    const applyPrimaryLabelCall:OpenAi.Chat.Completions.ChatCompletionMessageToolCall = chatCompletion.choices[0].message.tool_calls[0];
-    const args:any = await JSON.parse(applyPrimaryLabelCall.function.arguments);
-    const primaryLabel:string = args.primaryLabel+"";
-    const function_call_result_message:any = {
-      role: "tool",
-      content: JSON.stringify({
-        primaryLabel: primaryLabel
-      }),
-      tool_call_id: chatCompletion.choices[0].message.tool_calls[0].id
-    };
+  let aiResponse = "";
 
-    // First, apply the Primary Label
+  if (first.finishReason === "tool_calls" && first.toolCalls.length > 0) {
+    const call = first.toolCalls[0];
+    const args = JSON.parse(call.arguments);
+    const primaryLabel: string = String(args.primaryLabel);
+
     await addLabel(primaryLabel, context);
-    
-    // Then 
-    params.messages.push(chatCompletion.choices[0].message);
-    params.messages.push(function_call_result_message);
 
-    // TODO: make this look up the file
-    params.messages.push({
-      role: "user",
-      content: `Use the following .yml template to generate an official report:\n
+    const followUp: LlmMessage[] = [
+      ...messages,
+      {
+        role: 'assistant',
+        content: first.content,
+        toolCalls: first.toolCalls,
+      },
+      {
+        role: 'tool',
+        toolCallId: call.id,
+        content: JSON.stringify({ primaryLabel }),
+      },
+      {
+        role: 'user',
+        content: `Use the following .yml template to generate an official report:\n
                 name: Bug report\n
                 description: Report a bug or an issue that isn't working as expected.\n
                 title: "[BUG]: <Provide a clear, descriptive title>"\n
@@ -221,109 +218,68 @@ export async function primaryLabelCompletion(context:any, messageList:any) {
                       label: Additional context\n
                       description: Add any other context about the problem here.\n
                       placeholder: "Any additional information..."\n
-      `
-    });
+      `,
+      },
+    ];
 
-    const nextChatCompletion: OpenAi.Chat.Completions.ChatCompletion = await issuesAiClient.chat.completions.create(params);
-    aiResponse += nextChatCompletion.choices[0].message.content;
-
-  // If it can not decide on a Primary Label
+    const next = await complete(
+      { model: 'gpt-4o', messages: followUp, tools: [addPrimaryLabelTool] },
+      { handler: HANDLER },
+    );
+    aiResponse += next.content ?? "";
   } else {
-    // Return the message with additional questions
-    aiResponse += chatCompletion.choices[0].message.content;
-  };
+    aiResponse += first.content ?? "";
+  }
 
-  return aiResponse
-};
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-export async function issueReportCompletion(context:any | any, messages:any, primaryLabel?:string, template?:any) {
-  const issue = context.payload.issue;
-  const params:OpenAI.Chat.ChatCompletionCreateParams = {
-    messages: [
-      {
-        role: 'system',
-        content: systemPrompt,
-      },
-      {
-        role: 'user',
-        content: taskPrompt,
-      },
-      {
-        role: 'user',
-        content: `${(issue.labels && issue.labels.length > 0) ? 'Labels: ' + issue.labels.map((n:any) => n.name + ', ') + ' ' : ''}${issue.title}: ${issue.body}`,
-      },
-      ...messages
-    ],
-    model: 'gpt-4o-mini',
-  };
-  const chatCompletion:OpenAI.Chat.ChatCompletion = await issuesAiClient.chat.completions.create(params);
-  const aiResponse:string = chatCompletion.choices.map(n=>n.message.content).join(`\n`);
-  return aiResponse
-  
-  // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
-  // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
-};
+  return aiResponse;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-export async function issueDuplicateCheckCompletion(context:any | any, messages:any) {
-  const issue = context.payload.issue;
-  const params:OpenAI.Chat.ChatCompletionCreateParams = {
-    messages: [
-      {
-        role: 'system',
-        content: systemPrompt,
-      },
-      {
-        role: 'user',
-        content: taskPrompt,
-      },
-      {
-        role: 'user',
-        content: `${issue.labels.length > 0 ? 'Labels: ' + issue.labels.map((n:any) => n.name + ', ') + ' ' : ''}${issue.title}: ${issue.body}`,
-      },
-      ...messages
-    ],
-    model: 'gpt-4o',
-  };
-  const chatCompletion:OpenAI.Chat.ChatCompletion = await issuesAiClient.chat.completions.create(params);
-  const aiResponse:string = chatCompletion.choices.map(n=>n.message.content).join(`\n`);
-  return aiResponse
+export async function issueReportCompletion(context:any, messages:any, _primaryLabel?:string, _template?:any) {
+  const result = await complete(
+    {
+      model: 'gpt-4o-mini',
+      messages: buildBaseMessages(context, messages),
+    },
+    { handler: HANDLER },
+  );
+  return result.content ?? "";
 
   // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
   // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
-};
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-export async function issueCommentCompletion(context:any | any, messages:any) {
-  const issue = context.payload.issue;
-  const params:OpenAI.Chat.ChatCompletionCreateParams = {
-    messages: [
-      {
-        role: 'system',
-        content: systemPrompt,
-      },
-      {
-        role: 'user',
-        content: taskPrompt,
-      },
-      {
-        role: 'user',
-        content: `${issue.labels.length > 0 ? 'Labels: ' + issue.labels.map((n:any) => n.name + ', ') + ' ' : ''}${issue.title}: ${issue.body}`,
-      },
-      ...messages
-    ],
-    model: 'gpt-4o',
-  };
-  const chatCompletion:OpenAI.Chat.ChatCompletion = await issuesAiClient.chat.completions.create(params);
-  const aiResponse:string = chatCompletion.choices.map(n=>n.message.content).join(`\n`);
-  return aiResponse
+export async function issueDuplicateCheckCompletion(context:any, messages:any) {
+  const result = await complete(
+    {
+      model: 'gpt-4o',
+      messages: buildBaseMessages(context, messages),
+    },
+    { handler: HANDLER },
+  );
+  return result.content ?? "";
 
   // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
   // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
-};
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+export async function issueCommentCompletion(context:any, messages:any) {
+  const result = await complete(
+    {
+      model: 'gpt-4o',
+      messages: buildBaseMessages(context, messages),
+    },
+    { handler: HANDLER },
+  );
+  return result.content ?? "";
+
+  // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
+  // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -82,7 +82,7 @@ const addPrimaryLabelTool: LlmTool = {
 function buildBaseMessages(context: any, extra: any[]): LlmMessage[] {
   const issue = context.payload.issue;
   const labels = issue.labels && issue.labels.length > 0
-    ? 'Labels: ' + issue.labels.map((n: any) => n.name + ', ') + ' '
+    ? 'Labels: ' + issue.labels.map((n: any) => n.name).join(', ') + ' '
     : '';
   return [
     { role: 'system', content: systemPrompt },

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -51,7 +51,7 @@ const taskPrompt:string = `\
   \n
   ## Issue Intake Process
   The next message will contain a new issue. Follow these steps to complete the intake process:\n
-  1. Aanalyze the new issue.\n
+  1. Analyze the new issue.\n
     - If there is enough information in the issue comments you should pick an appropriate primaryLabel, otherwise, ask follow up questions until you can pick an appropriate primaryLabel.\n
   2. After you have picked a primaryLabel, call the addLabel function to add the primaryLabel to the issue.\n
   3. After you call addLabel, the runtime will reply with a user message containing the reportTemplate that corresponds with the primaryLabel. There is no separate getReportTemplate tool — wait for that message rather than trying to invoke a function.\n

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -54,10 +54,9 @@ const taskPrompt:string = `\
   1. Aanalyze the new issue.\n
     - If there is enough information in the issue comments you should pick an appropriate primaryLabel, otherwise, ask follow up questions until you can pick an appropriate primaryLabel.\n
   2. After you have picked a primaryLabel, call the addLabel function to add the primaryLabel to the issue.\n
-  3. Call the getReportTemplate function to get the reportTemplate that corresponds with the primaryLabel.\n
+  3. After you call addLabel, the runtime will reply with a user message containing the reportTemplate that corresponds with the primaryLabel. There is no separate getReportTemplate tool — wait for that message rather than trying to invoke a function.\n
   4. Compare the issue comments and the reportTemplate to determine if you have enough information for completing the entire reportTemplate.\n
     - If there is enough information in the issue comments you should respond with an officialReport that conforms to the reportTemplate, otherwise, ask follow up questions until you have all of the necessary information for generating the officialReport.
-  5. After picking a primaryLabel and generating an officialReport,
 `
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -101,7 +100,7 @@ export async function primaryLabelCompletion(context:any, messageList:any) {
       messages,
       tools: [addPrimaryLabelTool],
     },
-    { handler: HANDLER },
+    { handler: HANDLER, requireCapabilities: { toolUse: true } },
   );
 
   let aiResponse = "";
@@ -223,7 +222,7 @@ export async function primaryLabelCompletion(context:any, messageList:any) {
     ];
 
     const next = await complete(
-      { model: 'gpt-4o', messages: followUp, tools: [addPrimaryLabelTool] },
+      { model: 'gpt-4o', messages: followUp },
       { handler: HANDLER },
     );
     aiResponse += next.content ?? "";

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -246,8 +246,8 @@ export async function issueReportCompletion(context:any, messages:any, _primaryL
   );
   return result.content ?? "";
 
-  // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
-  // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
+  // There needs to be an abort here, something that checks if the conversation should be over and stops responding
+  // There should also be something that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -262,8 +262,8 @@ export async function issueDuplicateCheckCompletion(context:any, messages:any) {
   );
   return result.content ?? "";
 
-  // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
-  // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
+  // There needs to be an abort here, something that checks if the conversation should be over and stops responding
+  // There should also be something that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -278,8 +278,8 @@ export async function issueCommentCompletion(context:any, messages:any) {
   );
   return result.content ?? "";
 
-  // There needs to be an abort here, somthing that checks if the conversation should be over and stops responding
-  // There should also be soemthing that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
+  // There needs to be an abort here, something that checks if the conversation should be over and stops responding
+  // There should also be something that checks to make sure it is appropriate to respond at all, for instance, if a user specifically sends a message to someone else the bot should not respond
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/completions/issuesAi.ts
+++ b/src/completions/issuesAi.ts
@@ -79,7 +79,7 @@ const addPrimaryLabelTool: LlmTool = {
   },
 };
 
-function buildBaseMessages(context: any, extra: any[]): LlmMessage[] {
+function buildBaseMessages(context: any, extra: LlmMessage[] = []): LlmMessage[] {
   const issue = context.payload.issue;
   const labels = issue.labels && issue.labels.length > 0
     ? 'Labels: ' + issue.labels.map((n: any) => n.name).join(', ') + ' '

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -1,0 +1,53 @@
+import type { ProviderName } from "./types.js";
+
+const VALID_PROVIDERS: readonly ProviderName[] = [
+  "openai",
+  "anthropic",
+  "grok",
+  "v0",
+  "local",
+  "mock",
+] as const;
+
+export interface PortalConfig {
+  /** Default provider when no handler-specific override matches. */
+  defaultProvider: ProviderName;
+  /** Per-handler overrides. Key is the logical handler name passed to complete(). */
+  handlers: Record<string, ProviderName>;
+}
+
+function isProviderName(value: string): value is ProviderName {
+  return (VALID_PROVIDERS as readonly string[]).includes(value);
+}
+
+/**
+ * Resolve the portal config from environment variables.
+ *
+ * Recognized env vars:
+ * - LLM_DEFAULT_PROVIDER — global default (e.g. "openai", "anthropic", "mock").
+ * - LLM_HANDLER_<NAME>   — per-handler override (e.g. LLM_HANDLER_ISSUESAI=anthropic).
+ *                          Names are uppercased; underscores allowed.
+ *
+ * If LLM_DEFAULT_PROVIDER is unset, the default is "mock" so module load and
+ * tests succeed without any vendor key. Adapters self-report availability via
+ * isAvailable(); the portal falls back to mock when the configured adapter is
+ * unavailable.
+ */
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): PortalConfig {
+  const rawDefault = env.LLM_DEFAULT_PROVIDER?.trim().toLowerCase();
+  const defaultProvider: ProviderName =
+    rawDefault && isProviderName(rawDefault) ? rawDefault : "mock";
+
+  const handlers: Record<string, ProviderName> = {};
+  for (const [key, value] of Object.entries(env)) {
+    if (!key.startsWith("LLM_HANDLER_") || !value) continue;
+    const handlerName = key.slice("LLM_HANDLER_".length).toLowerCase();
+    if (!handlerName) continue;
+    const normalized = value.trim().toLowerCase();
+    if (isProviderName(normalized)) {
+      handlers[handlerName] = normalized;
+    }
+  }
+
+  return { defaultProvider, handlers };
+}

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -20,13 +20,24 @@ function isProviderName(value: string): value is ProviderName {
   return (VALID_PROVIDERS as readonly string[]).includes(value);
 }
 
+/** Normalize a handler name for lookup: lowercase, with underscores and dashes
+ * stripped. So `LLM_HANDLER_ISSUES_AI`, `LLM_HANDLER_ISSUESAI`, and a caller
+ * passing `handler: "issues_ai"` or `handler: "issuesAi"` all resolve to the
+ * same key. Keep both sides of the lookup (config build + resolveProvider) in
+ * sync via this helper. */
+export function normalizeHandlerName(name: string): string {
+  return name.toLowerCase().replace(/[_-]/g, "");
+}
+
 /**
  * Resolve the portal config from environment variables.
  *
  * Recognized env vars:
  * - LLM_DEFAULT_PROVIDER — global default (e.g. "openai", "anthropic", "mock").
  * - LLM_HANDLER_<NAME>   — per-handler override (e.g. LLM_HANDLER_ISSUESAI=anthropic).
- *                          Names are uppercased; underscores allowed.
+ *                          Underscores and dashes in <NAME> are stripped at lookup
+ *                          time, so LLM_HANDLER_ISSUES_AI matches a caller passing
+ *                          `handler: "issuesai"` (or vice versa).
  *
  * If LLM_DEFAULT_PROVIDER is unset, the default is "mock" so module load and
  * tests succeed without any vendor key. Adapters self-report availability via
@@ -51,7 +62,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): PortalConfig {
   const handlers: Record<string, ProviderName> = {};
   for (const [key, value] of Object.entries(env)) {
     if (!key.startsWith("LLM_HANDLER_") || !value) continue;
-    const handlerName = key.slice("LLM_HANDLER_".length).toLowerCase();
+    const handlerName = normalizeHandlerName(key.slice("LLM_HANDLER_".length));
     if (!handlerName) continue;
     const normalized = value.trim().toLowerCase();
     if (isProviderName(normalized)) {

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -35,8 +35,18 @@ function isProviderName(value: string): value is ProviderName {
  */
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): PortalConfig {
   const rawDefault = env.LLM_DEFAULT_PROVIDER?.trim().toLowerCase();
-  const defaultProvider: ProviderName =
-    rawDefault && isProviderName(rawDefault) ? rawDefault : "mock";
+  let defaultProvider: ProviderName = "mock";
+  if (rawDefault) {
+    if (isProviderName(rawDefault)) {
+      defaultProvider = rawDefault;
+    } else {
+      console.warn(
+        `[llm portal] Ignoring LLM_DEFAULT_PROVIDER=${JSON.stringify(env.LLM_DEFAULT_PROVIDER)} ` +
+          `— not a known provider name (${VALID_PROVIDERS.join(", ")}). ` +
+          `Falling back to "mock".`,
+      );
+    }
+  }
 
   const handlers: Record<string, ProviderName> = {};
   for (const [key, value] of Object.entries(env)) {
@@ -46,6 +56,12 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): PortalConfig {
     const normalized = value.trim().toLowerCase();
     if (isProviderName(normalized)) {
       handlers[handlerName] = normalized;
+    } else {
+      console.warn(
+        `[llm portal] Ignoring ${key}=${JSON.stringify(value)} ` +
+          `— not a known provider name (${VALID_PROVIDERS.join(", ")}). ` +
+          `This handler will use the default provider.`,
+      );
     }
   }
 

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,0 +1,111 @@
+import { loadConfig, type PortalConfig } from "./config.js";
+import { getProvider, listProviders } from "./registry.js";
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOpts,
+  CompleteOutput,
+  LlmProvider,
+  ProviderName,
+} from "./types.js";
+
+export type {
+  Capabilities,
+  CompleteInput,
+  CompleteOpts,
+  CompleteOutput,
+  FinishReason,
+  LlmMessage,
+  LlmProvider,
+  LlmTool,
+  LlmToolCall,
+  ProviderName,
+} from "./types.js";
+export { loadConfig } from "./config.js";
+export { getProvider, listProviders } from "./registry.js";
+
+let cachedConfig: PortalConfig | null = null;
+
+function config(): PortalConfig {
+  if (!cachedConfig) cachedConfig = loadConfig();
+  return cachedConfig;
+}
+
+/** Reset the cached config. Used by tests; not part of the runtime contract. */
+export function _resetConfigForTests(): void {
+  cachedConfig = null;
+}
+
+function meetsCapabilities(
+  provider: LlmProvider,
+  required: Partial<Capabilities> | undefined,
+): boolean {
+  if (!required) return true;
+  for (const [key, value] of Object.entries(required) as [
+    keyof Capabilities,
+    Capabilities[keyof Capabilities],
+  ][]) {
+    const actual = provider.capabilities[key];
+    if (typeof value === "boolean") {
+      if (value && !actual) return false;
+    } else if (typeof value === "number") {
+      if (typeof actual === "number" && actual < value) return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Resolve which provider should serve this call.
+ *
+ * Order of precedence:
+ *   1. opts.provider          — explicit override.
+ *   2. config.handlers[opts.handler] — per-handler config.
+ *   3. config.defaultProvider — global default.
+ *
+ * If the resolved provider is unavailable (missing key, etc.) or doesn't meet
+ * required capabilities, fall back to "mock" so module load and tests succeed
+ * without vendor keys.
+ */
+export function resolveProvider(opts: CompleteOpts = {}): LlmProvider {
+  const cfg = config();
+  let chosen: ProviderName;
+  if (opts.provider) {
+    chosen = opts.provider;
+  } else if (opts.handler && cfg.handlers[opts.handler.toLowerCase()]) {
+    chosen = cfg.handlers[opts.handler.toLowerCase()]!;
+  } else {
+    chosen = cfg.defaultProvider;
+  }
+  const provider = getProvider(chosen);
+  if (!provider.isAvailable() || !meetsCapabilities(provider, opts.requireCapabilities)) {
+    return getProvider("mock");
+  }
+  return provider;
+}
+
+/**
+ * Single entry point for LLM calls in handler code. Handlers must NOT import
+ * vendor SDKs directly; route through here. See docs/setup/llm-providers.md
+ * and ADR 0010.
+ */
+export async function complete(
+  input: CompleteInput,
+  opts: CompleteOpts = {},
+): Promise<CompleteOutput> {
+  const provider = resolveProvider(opts);
+  return provider.complete(input);
+}
+
+/**
+ * Find the first available provider matching the given capabilities, ignoring
+ * config overrides. Useful for diagnostics; handlers should normally use
+ * complete() with opts.handler.
+ */
+export function findCapableProvider(
+  required: Partial<Capabilities>,
+): LlmProvider | undefined {
+  return listProviders().find(
+    (p) => p.isAvailable() && meetsCapabilities(p, required),
+  );
+}

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -1,4 +1,4 @@
-import { loadConfig, type PortalConfig } from "./config.js";
+import { loadConfig, normalizeHandlerName, type PortalConfig } from "./config.js";
 import { getProvider, listProviders } from "./registry.js";
 import type {
   Capabilities,
@@ -72,8 +72,9 @@ export function resolveProvider(opts: CompleteOpts = {}): LlmProvider {
   let chosen: ProviderName;
   if (opts.provider) {
     chosen = opts.provider;
-  } else if (opts.handler && cfg.handlers[opts.handler.toLowerCase()]) {
-    chosen = cfg.handlers[opts.handler.toLowerCase()]!;
+  } else if (opts.handler) {
+    const key = normalizeHandlerName(opts.handler);
+    chosen = cfg.handlers[key] ?? cfg.defaultProvider;
   } else {
     chosen = cfg.defaultProvider;
   }

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -1,0 +1,177 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  FinishReason,
+  LlmMessage,
+  LlmProvider,
+  LlmTool,
+  LlmToolCall,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: true,
+  structuredOutput: true,
+  toolUse: true,
+  vision: true,
+  contextWindow: 200_000,
+};
+
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const API_URL = "https://api.anthropic.com/v1/messages";
+const API_VERSION = "2023-06-01";
+
+// Implemented against the Anthropic Messages REST API directly to avoid
+// pulling in @anthropic-ai/sdk as a runtime dependency for the bot. If we
+// later need streaming, structured outputs, or token counting, swap to the
+// SDK behind this same adapter surface.
+
+type NonSystemMessage = Exclude<LlmMessage, { role: "system" }>;
+
+interface SplitMessages {
+  system: string | undefined;
+  rest: NonSystemMessage[];
+}
+
+function splitSystem(messages: LlmMessage[]): SplitMessages {
+  const systemParts: string[] = [];
+  const rest: NonSystemMessage[] = [];
+  for (const m of messages) {
+    if (m.role === "system") {
+      systemParts.push(m.content);
+    } else {
+      rest.push(m);
+    }
+  }
+  return {
+    system: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
+    rest,
+  };
+}
+
+function toAnthropicMessages(messages: NonSystemMessage[]): any[] {
+  return messages.map((m) => {
+    if (m.role === "user") {
+      return { role: "user", content: m.content };
+    }
+    if (m.role === "assistant") {
+      const content: any[] = [];
+      if (m.content) content.push({ type: "text", text: m.content });
+      if (m.toolCalls) {
+        for (const tc of m.toolCalls) {
+          let parsed: unknown = {};
+          try {
+            parsed = JSON.parse(tc.arguments);
+          } catch {
+            parsed = { _raw: tc.arguments };
+          }
+          content.push({
+            type: "tool_use",
+            id: tc.id,
+            name: tc.name,
+            input: parsed,
+          });
+        }
+      }
+      return { role: "assistant", content };
+    }
+    // tool result -> Anthropic encodes as a user message with tool_result blocks
+    return {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: m.toolCallId,
+          content: m.content,
+        },
+      ],
+    };
+  });
+}
+
+function toAnthropicTools(tools: LlmTool[] | undefined): any[] | undefined {
+  if (!tools || tools.length === 0) return undefined;
+  return tools.map((t) => ({
+    name: t.name,
+    ...(t.description ? { description: t.description } : {}),
+    input_schema: t.parameters,
+  }));
+}
+
+function mapStopReason(reason: string | null | undefined): FinishReason {
+  switch (reason) {
+    case "end_turn":
+    case "stop_sequence":
+      return "stop";
+    case "tool_use":
+      return "tool_calls";
+    case "max_tokens":
+      return "length";
+    default:
+      return "other";
+  }
+}
+
+export const anthropicProvider: LlmProvider = {
+  name: "anthropic",
+  capabilities,
+  isAvailable() {
+    return Boolean(process.env.ANTHROPIC_API_KEY);
+  },
+  async complete(input: CompleteInput): Promise<CompleteOutput> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "Anthropic provider selected but ANTHROPIC_API_KEY is not set. " +
+          "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
+          "(see docs/setup/llm-providers.md).",
+      );
+    }
+    const { system, rest } = splitSystem(input.messages);
+    const body: Record<string, unknown> = {
+      model: input.model ?? DEFAULT_MODEL,
+      max_tokens: input.maxTokens ?? 4096,
+      messages: toAnthropicMessages(rest),
+    };
+    if (system) body.system = system;
+    const tools = toAnthropicTools(input.tools);
+    if (tools) body.tools = tools;
+    if (input.temperature !== undefined) body.temperature = input.temperature;
+
+    const response = await fetch(API_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": apiKey,
+        "anthropic-version": API_VERSION,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Anthropic API error ${response.status}: ${text.slice(0, 500)}`,
+      );
+    }
+    const data: any = await response.json();
+    const blocks: any[] = data.content ?? [];
+    const textParts: string[] = [];
+    const toolCalls: LlmToolCall[] = [];
+    for (const block of blocks) {
+      if (block.type === "text") textParts.push(block.text);
+      else if (block.type === "tool_use") {
+        toolCalls.push({
+          id: block.id,
+          name: block.name,
+          arguments: JSON.stringify(block.input ?? {}),
+        });
+      }
+    }
+    return {
+      content: textParts.length > 0 ? textParts.join("\n") : null,
+      toolCalls,
+      finishReason: mapStopReason(data.stop_reason),
+      raw: data,
+    };
+  },
+};

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -116,13 +116,13 @@ export const anthropicProvider: LlmProvider = {
   name: "anthropic",
   capabilities,
   isAvailable() {
-    return Boolean(process.env.ANTHROPIC_API_KEY);
+    return Boolean(process.env.ANTHROPIC_API_KEY?.trim());
   },
   async complete(input: CompleteInput): Promise<CompleteOutput> {
-    const apiKey = process.env.ANTHROPIC_API_KEY;
+    const apiKey = process.env.ANTHROPIC_API_KEY?.trim();
     if (!apiKey) {
       throw new Error(
-        "Anthropic provider selected but ANTHROPIC_API_KEY is not set. " +
+        "Anthropic provider selected but ANTHROPIC_API_KEY is missing or empty. " +
           "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
           "(see docs/setup/llm-providers.md).",
       );

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -11,7 +11,13 @@ import type {
 
 const capabilities: Capabilities = {
   streaming: true,
-  structuredOutput: true,
+  // Anthropic can produce structured output via tool-use schemas, but the
+  // portal's CompleteInput doesn't yet carry a schema/responseFormat field
+  // for callers to request it, and this adapter (Messages REST) doesn't pass
+  // anything that would constrain a non-tool response. See the parallel note
+  // in src/llm/providers/openai.ts. Flip to `true` once the portal grows the
+  // field and this adapter wires it up.
+  structuredOutput: false,
   toolUse: true,
   vision: true,
   contextWindow: 200_000,

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -19,7 +19,11 @@ const capabilities: Capabilities = {
   // field and this adapter wires it up.
   structuredOutput: false,
   toolUse: true,
-  vision: true,
+  // Anthropic accepts image inputs, but the portal's LlmMessage only carries
+  // string content — see the parallel notes in src/llm/providers/openai.ts.
+  // Flip to `true` once LlmMessage grows a multimodal content variant and
+  // this adapter wires it up.
+  vision: false,
   contextWindow: 200_000,
 };
 

--- a/src/llm/providers/grok.ts
+++ b/src/llm/providers/grok.ts
@@ -1,0 +1,33 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  LlmProvider,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: true,
+  structuredOutput: true,
+  toolUse: true,
+  vision: true,
+  contextWindow: 131_072,
+};
+
+// Stub adapter. xAI ships an OpenAI-compatible endpoint at https://api.x.ai/v1
+// so this can be wired by reusing the openai adapter pattern with a custom
+// baseURL. Left as a stub until a handler actually targets Grok — the portal
+// is the place to add it; do not import the xAI SDK from a handler.
+export const grokProvider: LlmProvider = {
+  name: "grok",
+  capabilities,
+  isAvailable() {
+    return Boolean(process.env.XAI_API_KEY);
+  },
+  async complete(_input: CompleteInput): Promise<CompleteOutput> {
+    throw new Error(
+      "grok provider is not implemented yet. " +
+        "Wire it via xAI's OpenAI-compatible endpoint (https://api.x.ai/v1) " +
+        "when the first handler targets it.",
+    );
+  },
+};

--- a/src/llm/providers/local.ts
+++ b/src/llm/providers/local.ts
@@ -61,15 +61,18 @@ export const localProvider: LlmProvider = {
   isAvailable() {
     // Local servers don't expose a uniform health check, so availability is
     // gated on opt-in via env. Adapters self-report; the actual reachability
-    // check happens in complete().
-    return Boolean(process.env.LLM_LOCAL_BASE_URL || process.env.LLM_LOCAL_MODEL);
+    // check happens in complete(). Whitespace-only env values are treated as
+    // unset so a stray space doesn't silently route traffic to a default URL.
+    return Boolean(
+      process.env.LLM_LOCAL_BASE_URL?.trim() ||
+        process.env.LLM_LOCAL_MODEL?.trim(),
+    );
   },
   async complete(input: CompleteInput): Promise<CompleteOutput> {
-    const baseUrl = (process.env.LLM_LOCAL_BASE_URL ?? DEFAULT_BASE_URL).replace(
-      /\/$/,
-      "",
-    );
-    const model = input.model ?? process.env.LLM_LOCAL_MODEL ?? DEFAULT_MODEL;
+    const baseUrlEnv = process.env.LLM_LOCAL_BASE_URL?.trim();
+    const modelEnv = process.env.LLM_LOCAL_MODEL?.trim();
+    const baseUrl = (baseUrlEnv || DEFAULT_BASE_URL).replace(/\/$/, "");
+    const model = input.model ?? modelEnv ?? DEFAULT_MODEL;
     const body: Record<string, unknown> = {
       model,
       messages: toOpenAiCompatibleMessages(input.messages),

--- a/src/llm/providers/local.ts
+++ b/src/llm/providers/local.ts
@@ -77,7 +77,8 @@ export const localProvider: LlmProvider = {
     if (input.temperature !== undefined) body.temperature = input.temperature;
     if (input.maxTokens !== undefined) body.max_tokens = input.maxTokens;
 
-    const response = await fetch(`${baseUrl}/chat/completions`, {
+    const url = `${baseUrl}/chat/completions`;
+    const response = await fetch(url, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(body),
@@ -85,7 +86,7 @@ export const localProvider: LlmProvider = {
     if (!response.ok) {
       const text = await response.text();
       throw new Error(
-        `Local LLM error ${response.status} from ${baseUrl}: ${text.slice(0, 500)}`,
+        `Local LLM error ${response.status} from ${url}: ${text.slice(0, 500)}`,
       );
     }
     const data: any = await response.json();

--- a/src/llm/providers/local.ts
+++ b/src/llm/providers/local.ts
@@ -1,0 +1,108 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  FinishReason,
+  LlmMessage,
+  LlmProvider,
+  LlmToolCall,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: false,
+  structuredOutput: false,
+  toolUse: false,
+  vision: false,
+  contextWindow: 0,
+};
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:11434/v1"; // Ollama default
+const DEFAULT_MODEL = "llama3.1";
+
+// Talks to any OpenAI-Chat-Completions-compatible local server: Ollama (with
+// /v1 enabled), llama.cpp's --api server, LM Studio's local server, vLLM, etc.
+// Configured via LLM_LOCAL_BASE_URL and LLM_LOCAL_MODEL. Tool use varies by
+// model and runtime so the capability flag is conservatively false; handlers
+// that need tools should not route here.
+
+function toOpenAiCompatibleMessages(messages: LlmMessage[]): any[] {
+  return messages.map((m) => {
+    switch (m.role) {
+      case "system":
+      case "user":
+        return { role: m.role, content: m.content };
+      case "assistant":
+        return { role: "assistant", content: m.content ?? "" };
+      case "tool":
+        return {
+          role: "tool",
+          content: m.content,
+          tool_call_id: m.toolCallId,
+        };
+    }
+  });
+}
+
+function mapFinishReason(reason: string | null | undefined): FinishReason {
+  switch (reason) {
+    case "stop":
+    case "length":
+      return reason;
+    case "tool_calls":
+      return "tool_calls";
+    default:
+      return "other";
+  }
+}
+
+export const localProvider: LlmProvider = {
+  name: "local",
+  capabilities,
+  isAvailable() {
+    // Local servers don't expose a uniform health check, so availability is
+    // gated on opt-in via env. Adapters self-report; the actual reachability
+    // check happens in complete().
+    return Boolean(process.env.LLM_LOCAL_BASE_URL || process.env.LLM_LOCAL_MODEL);
+  },
+  async complete(input: CompleteInput): Promise<CompleteOutput> {
+    const baseUrl = (process.env.LLM_LOCAL_BASE_URL ?? DEFAULT_BASE_URL).replace(
+      /\/$/,
+      "",
+    );
+    const model = input.model ?? process.env.LLM_LOCAL_MODEL ?? DEFAULT_MODEL;
+    const body: Record<string, unknown> = {
+      model,
+      messages: toOpenAiCompatibleMessages(input.messages),
+    };
+    if (input.temperature !== undefined) body.temperature = input.temperature;
+    if (input.maxTokens !== undefined) body.max_tokens = input.maxTokens;
+
+    const response = await fetch(`${baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `Local LLM error ${response.status} from ${baseUrl}: ${text.slice(0, 500)}`,
+      );
+    }
+    const data: any = await response.json();
+    const choice = data.choices?.[0];
+    const message = choice?.message ?? {};
+    const toolCalls: LlmToolCall[] = (message.tool_calls ?? []).map(
+      (tc: any) => ({
+        id: tc.id,
+        name: tc.function?.name ?? "",
+        arguments: tc.function?.arguments ?? "",
+      }),
+    );
+    return {
+      content: message.content ?? null,
+      toolCalls,
+      finishReason: mapFinishReason(choice?.finish_reason),
+      raw: data,
+    };
+  },
+};

--- a/src/llm/providers/mock.ts
+++ b/src/llm/providers/mock.ts
@@ -5,10 +5,15 @@ import type {
   LlmProvider,
 } from "../types.js";
 
+// Mock returns no tool calls (see complete() below — toolCalls is always []).
+// Reporting toolUse:false keeps capability routing honest: findCapableProvider
+// won't claim mock satisfies a toolUse:true requirement. resolveProvider still
+// falls back to mock unconditionally when nothing else is available, so this
+// is about diagnostic accuracy, not routing behavior.
 const capabilities: Capabilities = {
   streaming: false,
   structuredOutput: false,
-  toolUse: true,
+  toolUse: false,
   vision: false,
   contextWindow: 0,
 };

--- a/src/llm/providers/mock.ts
+++ b/src/llm/providers/mock.ts
@@ -1,0 +1,41 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  LlmProvider,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: false,
+  structuredOutput: false,
+  toolUse: true,
+  vision: false,
+  contextWindow: 0,
+};
+
+/**
+ * No-op adapter used as the default when no provider env is configured (e.g. in
+ * tests). Returns deterministic placeholder content so handlers can be exercised
+ * end-to-end without a real vendor key.
+ */
+export const mockProvider: LlmProvider = {
+  name: "mock",
+  capabilities,
+  isAvailable() {
+    return true;
+  },
+  async complete(input: CompleteInput): Promise<CompleteOutput> {
+    const lastUser = [...input.messages]
+      .reverse()
+      .find((m) => m.role === "user");
+    const echo =
+      lastUser && "content" in lastUser
+        ? `[mock] ${lastUser.content.slice(0, 200)}`
+        : "[mock] no user message";
+    return {
+      content: echo,
+      toolCalls: [],
+      finishReason: "stop",
+    };
+  },
+};

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -35,10 +35,10 @@ async function getClient(): Promise<any> {
   if (cachedClient) return cachedClient;
   if (cachedClientPromise) return cachedClientPromise;
   cachedClientPromise = (async () => {
-    const apiKey = process.env.OPENAI_API_KEY;
+    const apiKey = process.env.OPENAI_API_KEY?.trim();
     if (!apiKey) {
       throw new Error(
-        "OpenAI provider selected but OPENAI_API_KEY is not set. " +
+        "OpenAI provider selected but OPENAI_API_KEY is missing or empty. " +
           "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
           "(see docs/setup/llm-providers.md).",
       );
@@ -113,7 +113,7 @@ export const openaiProvider: LlmProvider = {
   name: "openai",
   capabilities,
   isAvailable() {
-    return Boolean(process.env.OPENAI_API_KEY);
+    return Boolean(process.env.OPENAI_API_KEY?.trim());
   },
   async complete(input: CompleteInput): Promise<CompleteOutput> {
     const client = await getClient();

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -1,0 +1,132 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  FinishReason,
+  LlmMessage,
+  LlmProvider,
+  LlmTool,
+  LlmToolCall,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: true,
+  structuredOutput: true,
+  toolUse: true,
+  vision: true,
+  contextWindow: 128_000,
+};
+
+const DEFAULT_MODEL = "gpt-4o-mini";
+
+// Cached client + module ref. The OpenAI SDK is required lazily so that
+// importing the portal — or any handler that uses it — never reaches for
+// OPENAI_API_KEY at module load. A missing key here only matters when this
+// adapter is actually selected and invoked.
+let cachedClient: unknown | null = null;
+
+async function getClient(): Promise<any> {
+  if (cachedClient) return cachedClient;
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "OpenAI provider selected but OPENAI_API_KEY is not set. " +
+        "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
+        "(see docs/setup/llm-providers.md).",
+    );
+  }
+  const mod = await import("openai");
+  const OpenAI = (mod as any).default ?? (mod as any).OpenAI;
+  cachedClient = new OpenAI({ apiKey });
+  return cachedClient;
+}
+
+function toOpenAiMessages(messages: LlmMessage[]): any[] {
+  return messages.map((m) => {
+    switch (m.role) {
+      case "system":
+      case "user":
+        return { role: m.role, content: m.content };
+      case "assistant":
+        return {
+          role: "assistant",
+          content: m.content,
+          ...(m.toolCalls && m.toolCalls.length > 0
+            ? {
+                tool_calls: m.toolCalls.map((tc) => ({
+                  id: tc.id,
+                  type: "function",
+                  function: { name: tc.name, arguments: tc.arguments },
+                })),
+              }
+            : {}),
+        };
+      case "tool":
+        return {
+          role: "tool",
+          content: m.content,
+          tool_call_id: m.toolCallId,
+        };
+    }
+  });
+}
+
+function toOpenAiTools(tools: LlmTool[] | undefined): any[] | undefined {
+  if (!tools || tools.length === 0) return undefined;
+  return tools.map((t) => ({
+    type: "function",
+    function: {
+      name: t.name,
+      ...(t.description ? { description: t.description } : {}),
+      parameters: t.parameters,
+    },
+  }));
+}
+
+function mapFinishReason(reason: string | null | undefined): FinishReason {
+  switch (reason) {
+    case "stop":
+    case "tool_calls":
+    case "length":
+    case "content_filter":
+      return reason;
+    default:
+      return "other";
+  }
+}
+
+export const openaiProvider: LlmProvider = {
+  name: "openai",
+  capabilities,
+  isAvailable() {
+    return Boolean(process.env.OPENAI_API_KEY);
+  },
+  async complete(input: CompleteInput): Promise<CompleteOutput> {
+    const client = await getClient();
+    const params: Record<string, unknown> = {
+      model: input.model ?? DEFAULT_MODEL,
+      messages: toOpenAiMessages(input.messages),
+    };
+    const tools = toOpenAiTools(input.tools);
+    if (tools) params.tools = tools;
+    if (input.temperature !== undefined) params.temperature = input.temperature;
+    if (input.maxTokens !== undefined) params.max_tokens = input.maxTokens;
+
+    const response = await client.chat.completions.create(params);
+    const choice = response.choices[0];
+    const message = choice.message;
+    const toolCalls: LlmToolCall[] = (message.tool_calls ?? []).map(
+      (tc: any) => ({
+        id: tc.id,
+        name: tc.function.name,
+        arguments: tc.function.arguments,
+      }),
+    );
+    return {
+      content: message.content ?? null,
+      toolCalls,
+      finishReason: mapFinishReason(choice.finish_reason),
+      raw: response,
+    };
+  },
+};

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -20,7 +20,13 @@ const capabilities: Capabilities = {
   // than honestly declining. Flip to `true` once CompleteInput grows the field.
   structuredOutput: false,
   toolUse: true,
-  vision: true,
+  // OpenAI accepts image inputs, but the portal's LlmMessage only carries
+  // string content — there's no multimodal payload reaching this adapter,
+  // so advertising vision would let `requireCapabilities: { vision: true }`
+  // route here without anything actually attaching an image. Same reasoning
+  // as the structuredOutput note above. Flip to `true` once LlmMessage grows
+  // a multimodal content variant.
+  vision: false,
   contextWindow: 128_000,
 };
 

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -11,7 +11,14 @@ import type {
 
 const capabilities: Capabilities = {
   streaming: true,
-  structuredOutput: true,
+  // OpenAI supports JSON-schema-constrained output via response_format, but
+  // the portal's CompleteInput surface doesn't yet carry a schema/responseFormat
+  // field — there's no way for callers to request structured output, and this
+  // adapter doesn't pass anything to the SDK that would constrain the response.
+  // Advertising the capability would let `requireCapabilities: { structuredOutput: true }`
+  // route here without anything actually enforcing structure, which is worse
+  // than honestly declining. Flip to `true` once CompleteInput grows the field.
+  structuredOutput: false,
   toolUse: true,
   vision: true,
   contextWindow: 128_000,

--- a/src/llm/providers/openai.ts
+++ b/src/llm/providers/openai.ts
@@ -23,22 +23,36 @@ const DEFAULT_MODEL = "gpt-4o-mini";
 // importing the portal — or any handler that uses it — never reaches for
 // OPENAI_API_KEY at module load. A missing key here only matters when this
 // adapter is actually selected and invoked.
+//
+// We cache the in-flight Promise (not just the resolved client) so that
+// concurrent webhook handlers racing on first init don't each kick off a
+// separate `import("openai")` + `new OpenAI(...)`. On failure we clear
+// the promise so the next caller can retry.
 let cachedClient: unknown | null = null;
+let cachedClientPromise: Promise<any> | null = null;
 
 async function getClient(): Promise<any> {
   if (cachedClient) return cachedClient;
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) {
-    throw new Error(
-      "OpenAI provider selected but OPENAI_API_KEY is not set. " +
-        "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
-        "(see docs/setup/llm-providers.md).",
-    );
-  }
-  const mod = await import("openai");
-  const OpenAI = (mod as any).default ?? (mod as any).OpenAI;
-  cachedClient = new OpenAI({ apiKey });
-  return cachedClient;
+  if (cachedClientPromise) return cachedClientPromise;
+  cachedClientPromise = (async () => {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "OpenAI provider selected but OPENAI_API_KEY is not set. " +
+          "Set the env var or change the provider via LLM_DEFAULT_PROVIDER " +
+          "(see docs/setup/llm-providers.md).",
+      );
+    }
+    const mod = await import("openai");
+    const OpenAI = (mod as any).default ?? (mod as any).OpenAI;
+    const client = new OpenAI({ apiKey });
+    cachedClient = client;
+    return client;
+  })().catch((error) => {
+    cachedClientPromise = null;
+    throw error;
+  });
+  return cachedClientPromise;
 }
 
 function toOpenAiMessages(messages: LlmMessage[]): any[] {

--- a/src/llm/providers/v0.ts
+++ b/src/llm/providers/v0.ts
@@ -1,0 +1,33 @@
+import type {
+  Capabilities,
+  CompleteInput,
+  CompleteOutput,
+  LlmProvider,
+} from "../types.js";
+
+const capabilities: Capabilities = {
+  streaming: true,
+  structuredOutput: false,
+  toolUse: false,
+  vision: true,
+  contextWindow: 128_000,
+};
+
+// Stub adapter for Vercel v0. The v0 platform exposes an OpenAI-compatible
+// chat completions API at https://api.v0.dev/v1 — wire this when we have a
+// handler that actually targets it. Until then, throw on use so misconfiguration
+// fails loudly rather than silently routing somewhere unexpected.
+export const v0Provider: LlmProvider = {
+  name: "v0",
+  capabilities,
+  isAvailable() {
+    return Boolean(process.env.V0_API_KEY);
+  },
+  async complete(_input: CompleteInput): Promise<CompleteOutput> {
+    throw new Error(
+      "v0 provider is not implemented yet. " +
+        "Wire it via v0's OpenAI-compatible endpoint (https://api.v0.dev/v1) " +
+        "when the first handler targets it.",
+    );
+  },
+};

--- a/src/llm/registry.ts
+++ b/src/llm/registry.ts
@@ -1,0 +1,24 @@
+import { anthropicProvider } from "./providers/anthropic.js";
+import { grokProvider } from "./providers/grok.js";
+import { localProvider } from "./providers/local.js";
+import { mockProvider } from "./providers/mock.js";
+import { openaiProvider } from "./providers/openai.js";
+import { v0Provider } from "./providers/v0.js";
+import type { LlmProvider, ProviderName } from "./types.js";
+
+const providers: Record<ProviderName, LlmProvider> = {
+  openai: openaiProvider,
+  anthropic: anthropicProvider,
+  grok: grokProvider,
+  v0: v0Provider,
+  local: localProvider,
+  mock: mockProvider,
+};
+
+export function getProvider(name: ProviderName): LlmProvider {
+  return providers[name];
+}
+
+export function listProviders(): LlmProvider[] {
+  return Object.values(providers);
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,0 +1,94 @@
+// Provider-neutral message and tool-call shapes used by the LLM portal.
+// Adapters in src/llm/providers/ translate these to/from vendor SDKs.
+
+export type ProviderName =
+  | "openai"
+  | "anthropic"
+  | "grok"
+  | "v0"
+  | "local"
+  | "mock";
+
+export type LlmRole = "system" | "user" | "assistant" | "tool";
+
+export interface LlmToolCall {
+  id: string;
+  name: string;
+  /** JSON-encoded arguments string, mirroring OpenAI/Anthropic conventions. */
+  arguments: string;
+}
+
+export type LlmMessage =
+  | { role: "system"; content: string }
+  | { role: "user"; content: string }
+  | {
+      role: "assistant";
+      content: string | null;
+      toolCalls?: LlmToolCall[];
+    }
+  | {
+      role: "tool";
+      toolCallId: string;
+      content: string;
+    };
+
+export interface LlmTool {
+  name: string;
+  description?: string;
+  /** JSON Schema describing the function parameters. */
+  parameters: Record<string, unknown>;
+}
+
+export interface CompleteInput {
+  messages: LlmMessage[];
+  /** Model id understood by the chosen provider. Optional — adapters fall back to a default. */
+  model?: string;
+  tools?: LlmTool[];
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export type FinishReason =
+  | "stop"
+  | "tool_calls"
+  | "length"
+  | "content_filter"
+  | "other";
+
+export interface CompleteOutput {
+  content: string | null;
+  toolCalls: LlmToolCall[];
+  finishReason: FinishReason;
+  /** Provider-specific raw response, for adapters that need to round-trip vendor state. */
+  raw?: unknown;
+}
+
+export interface Capabilities {
+  streaming: boolean;
+  structuredOutput: boolean;
+  toolUse: boolean;
+  vision: boolean;
+  /** Approximate context window in tokens. 0 means unknown. */
+  contextWindow: number;
+}
+
+export interface LlmProvider {
+  readonly name: ProviderName;
+  readonly capabilities: Capabilities;
+  /**
+   * Returns true if the adapter has the env/config it needs to actually call the
+   * vendor. Used by the portal to decide whether to fall back to the mock adapter.
+   * Must not instantiate any SDK client.
+   */
+  isAvailable(): boolean;
+  complete(input: CompleteInput): Promise<CompleteOutput>;
+}
+
+export interface CompleteOpts {
+  /** Logical handler name, e.g. "issuesAi". Looked up in PortalConfig.handlers. */
+  handler?: string;
+  /** Explicit provider override; bypasses handler lookup. */
+  provider?: ProviderName;
+  /** Require these capabilities; fall back to mock if no configured provider satisfies them. */
+  requireCapabilities?: Partial<Capabilities>;
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -89,6 +89,6 @@ export interface CompleteOpts {
   handler?: string;
   /** Explicit provider override; bypasses handler lookup. */
   provider?: ProviderName;
-  /** Require these capabilities; fall back to mock if no configured provider satisfies them. */
+  /** Require these capabilities on the resolved provider; fall back to mock if it does not satisfy them. */
   requireCapabilities?: Partial<Capabilities>;
 }

--- a/src/utils/issuesUtils.ts
+++ b/src/utils/issuesUtils.ts
@@ -44,7 +44,7 @@ export async function fetchRepo(context:any) {
 
 // Applies a Label to an Issue
 export async function addLabel(label: string, context:any) {
-  context.octokit.issues.addLabels(
+  return context.octokit.issues.addLabels(
     context.issue({
       labels: [label],
     })
@@ -53,7 +53,7 @@ export async function addLabel(label: string, context:any) {
 
 // Removes a Label to an Issue
 export async function removeLabel(label: string, context:any) {
-  context.octokit.issues.removeLabel(
+  return context.octokit.issues.removeLabel(
     context.issue({
       labels: [label],
     })

--- a/test/fixtures/issues.opened.json
+++ b/test/fixtures/issues.opened.json
@@ -12,6 +12,9 @@
       "login": "hiimbex"
     }
   },
+  "sender": {
+    "login": "hiimbex"
+  },
   "installation": {
     "id": 2
   }


### PR DESCRIPTION
## Summary

Adds a config-driven LLM portal at `src/llm/` with per-vendor adapters (OpenAI + Anthropic + local wired; Grok + v0 stubbed; mock for tests). Handlers now call `complete(input, opts)` instead of importing vendor SDKs directly. Adapters construct their SDK clients lazily, so module load no longer requires any vendor key.

Fixes the module-load crash that surfaced during round-1 verify on PR #13 (commit ea43d59): `src/completions/issuesAi.ts` previously called `new OpenAI(...)` at import, which threw before tests could even load when `OPENAI_API_KEY` was unset.

## Related

- Issue: #14
- ADR: `docs/adr/0010-llm-provider-portal.md`
- Provider setup: `docs/setup/llm-providers.md`
- Backlinks: ADR 0005 § Classifier boundary (the portal is the transport; templated-classification discipline still applies)

## What changed

- `src/llm/types.ts` — `LlmMessage`, `LlmTool`, `CompleteInput`, `CompleteOutput`, `Capabilities`, `LlmProvider`.
- `src/llm/config.ts` — env-driven config (`LLM_DEFAULT_PROVIDER`, `LLM_HANDLER_<NAME>`); defaults to `mock`.
- `src/llm/registry.ts` + `src/llm/index.ts` — registry, `resolveProvider`, `complete()`, `findCapableProvider`.
- `src/llm/providers/openai.ts` — lazy `import("openai")`; required key only when actually invoked.
- `src/llm/providers/anthropic.ts` — Messages REST API via `fetch` (no new SDK dep).
- `src/llm/providers/local.ts` — OpenAI-compatible chat completions via `fetch` for Ollama / llama.cpp / LM Studio / vLLM.
- `src/llm/providers/grok.ts`, `v0.ts` — stubs that throw with a wire-up hint.
- `src/llm/providers/mock.ts` — deterministic placeholder; default for tests.
- `src/completions/issuesAi.ts` — migrated off `new OpenAi(...)` at module scope to portal calls; tool definition switched from Zod to JSON Schema (the only Zod usage in this file).
- `test/fixtures/issues.opened.json` — added the missing `sender` field so the fixture can be loaded by `test/index.test.ts` without an immediate `sender.login` crash.
- `CLAUDE.md`, `AGENTS.md` — portal-only rule for handler code.
- `docs/adr/0010-llm-provider-portal.md` (new), `docs/adr/README.md` index updated, `docs/setup/llm-providers.md` (new).

## Test plan

- [x] **Module-load fix verified.** `unset OPENAI_API_KEY && npx vitest run` no longer fails at module load. Before: `Error: The OPENAI_API_KEY environment variable is missing or empty ... new OpenAI ... src/completions/issuesAi.ts:12:24`. After: tests load successfully and `src/completions/issuesAi.ts` is importable without any provider key.
- [x] Type check on the new portal code passes (`npx tsc --noEmit` reports no errors in `src/llm/` or `src/completions/`).
- [ ] Unit/integration tests pass (`npm test`) — see "Remaining failures" below.
- [ ] Manual verification: set `LLM_HANDLER_ISSUESAI=anthropic` + `ANTHROPIC_API_KEY=...` and confirm an issue intake routes through the Anthropic adapter end-to-end. Not yet exercised in this PR; the portal's contract is unit-testable but requires fixture work tracked separately.

## Remaining failures (not introduced here)

Surfacing these so the verify run is interpretable:

1. `test/index.test.ts` — the `sender.login` crash from the missing fixture field is **fixed** in this PR (commit 047fc17 added the `sender` block to `test/fixtures/issues.opened.json`). However, the test still fails downstream: the labels-mock now returns HTTP 500 against `POST https://api.github.com/repos/hiimbex/testing-things/issues/1/labels` because the test setup hasn't registered an `issues/labels` mock matching the new request. That mock is unrelated to the portal and worth its own follow-up.
2. `npm run build` — pre-existing TS errors in `node_modules/lru-cache/dist/commonjs/index.d.ts` (transitive iterator-type incompatibility) and `node_modules/openai/src/core.ts` (unused-var diagnostics surfacing under `noUnusedLocals`). Plus a handful of pre-existing unused-var errors in `src/utils/issuesUtils.ts`, `src/workflows/issueIntake.ts`, and `src/workflows/issueWatcher.ts`. All reproducible on `origin/dev`. The new code in `src/llm/` and the migrated `src/completions/issuesAi.ts` type-check clean (`npx tsc --noEmit` reports zero errors from files I changed/added).

Both deserve their own follow-up PRs against `dev` — flagging them rather than expanding scope here.

## Checklist

- [x] One logical change per PR (portal + the one migration that proves it works)
- [x] CLAUDE.md / AGENTS.md rules respected — portal-only rule documented
- [x] ADR added (0010, MADR format), backlinks ADR 0005 § Classifier boundary
- [x] No new runtime dependencies added — Anthropic and local providers use `fetch`; OpenAI is the existing dep
- [x] `llm-wiki/` not touched (this is architecture-level; the ADR + setup doc are the right home)

## Notes for reviewer

- The capability flag taxonomy is intentionally small (5 fields). Easy to extend; the cost is honestly reportable per vendor.
- `mock` is the silent fallback when a configured provider is unavailable. That's deliberate for test ergonomics; production should set the keys it expects to use, and a stub adapter (Grok/v0) throws loudly if explicitly selected.
- Tools are described as JSON Schema directly to avoid coupling the portal to Zod. The one place we used Zod (`addPrimaryLabelTool`) is now a JSON Schema literal.
- Adapter `isAvailable()` checks env only — never instantiates a client. This is the invariant that prevents issue #14 from recurring; please flag if you spot a code path that violates it.
